### PR TITLE
Changelog: Trim version prefix also if it ends with a colon

### DIFF
--- a/pkg/changelog/builder.go
+++ b/pkg/changelog/builder.go
@@ -137,7 +137,7 @@ func issueAsMarkdown(issue *github.Issue) string {
 	return out.String()
 }
 
-var releaseStreamPrefixPattern = regexp.MustCompile(`^(\[[^]]+\]) (.*)$`)
+var releaseStreamPrefixPattern = regexp.MustCompile(`^(\[[^]]+\]:?) (.*)$`)
 
 func stripReleaseStreamPrefix(input string) string {
 	if releaseStreamPrefixPattern.MatchString(input) {

--- a/pkg/changelog/builder_test.go
+++ b/pkg/changelog/builder_test.go
@@ -71,6 +71,22 @@ func TestIssueLine(t *testing.T) {
 			expectedOutput: "- **Chore:** hello. [#123](https://github.com/grafana/grafana/issues/123)\n",
 		},
 		{
+			name: "version-prefix-doubledigit",
+			issue: func(i *github.Issue) {
+				i.Title = pointerOf("[v10.0.x] Chore: hello")
+				i.Number = pointerOf(123)
+			},
+			expectedOutput: "- **Chore:** hello. [#123](https://github.com/grafana/grafana/issues/123)\n",
+		},
+		{
+			name: "version-prefix-plus-colon",
+			issue: func(i *github.Issue) {
+				i.Title = pointerOf("[v10.0.x]: Chore: hello")
+				i.Number = pointerOf(123)
+			},
+			expectedOutput: "- **Chore:** hello. [#123](https://github.com/grafana/grafana/issues/123)\n",
+		},
+		{
 			name: "enterprise-with-category",
 			issue: func(i *github.Issue) {
 				i.Title = pointerOf("hello: world")


### PR DESCRIPTION
Previously, things like `[v10.0.x]: hello world` didn't result in the prefix being trimmed. That only worked for `[v10.0.x] hello world`.