### PR TITLE
Update-changelog: Add newline if notice ends with a code-block

### DIFF
--- a/pkg/changelog/builder.go
+++ b/pkg/changelog/builder.go
@@ -208,7 +208,18 @@ func getNotice(issue *github.Issue, sectionStart string) string {
 			}
 			result.WriteString(l)
 			if idx == lastLine {
-				result.WriteString(" Issue ")
+				// Trim tailing whitespaces before finalizing the output:
+				output := strings.Builder{}
+				output.WriteString(strings.TrimSpace(result.String()))
+				result = strings.Builder{}
+				result.WriteString(output.String())
+
+				if strings.HasSuffix(output.String(), "```") {
+					result.WriteString("\n")
+				} else {
+					result.WriteString(" ")
+				}
+				result.WriteString("Issue ")
 				result.WriteString(getIssueLink(issue))
 			}
 		}

--- a/pkg/changelog/builder_test.go
+++ b/pkg/changelog/builder_test.go
@@ -37,6 +37,33 @@ func TestDeprecationNotice(t *testing.T) {
 			},
 			expectedOutput: "hello\nworld. Issue [#123](https://github.com/grafana/grafana/issues/123)",
 		},
+		{
+			name: "strip-extra-empty-tail",
+			issue: func(i *github.Issue) {
+				i.Number = pointerOf(123)
+				i.Body = pointerOf("something else\n## Deprecation notice:\nhello\nworld.\n\n\n\n\n")
+			},
+			expectedOutput: "hello\nworld. Issue [#123](https://github.com/grafana/grafana/issues/123)",
+		},
+		// If the notice ends with a codeblock, then we have to introduce an extra newline:
+		{
+			name: "codeblock-end",
+			issue: func(i *github.Issue) {
+				i.Number = pointerOf(123)
+				i.Body = pointerOf("something else\n## Deprecation notice:\n```\nhello\n```")
+			},
+			expectedOutput: "```\nhello\n```\nIssue [#123](https://github.com/grafana/grafana/issues/123)",
+		},
+		// If the notice ends with a codeblock and also with a newline (or
+		// more) then only a single newline should remain:
+		{
+			name: "codeblock-end-plus-newline",
+			issue: func(i *github.Issue) {
+				i.Number = pointerOf(123)
+				i.Body = pointerOf("something else\n## Deprecation notice:\n```\nhello\n```\n\n\n")
+			},
+			expectedOutput: "```\nhello\n```\nIssue [#123](https://github.com/grafana/grafana/issues/123)",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
This will fix issues similar to https://github.com/grafana/grafana/issues/69589 in the future. I will fix that one manually for 10.0.0-preview, though.