### PR TITLE
Auto-milestone: Set the milestone of a PR automatically

### DIFF
--- a/auto-milestone/README.md
+++ b/auto-milestone/README.md
@@ -1,0 +1,10 @@
+# auto-milestone
+
+This action is usually triggered right after merging a pull request in order to set the correct milestone for it.
+The milestone is determined by the Grafana version of the branch the PR is merged into.
+
+You can also dry-run it using the following command:
+
+```
+$ go run ./auto-milestone --repository grafana/grafana $PR_NUMBER
+```

--- a/auto-milestone/README.md
+++ b/auto-milestone/README.md
@@ -6,5 +6,25 @@ The milestone is determined by the Grafana version of the branch the PR is merge
 You can also dry-run it using the following command:
 
 ```
-$ go run ./auto-milestone --repository grafana/grafana $PR_NUMBER
+$ go run ./auto-milestone --repo grafana/grafana $PR_NUMBER
+```
+
+## Example workflow:
+
+```yaml
+name: Auto-milestone
+on:
+  pull_request:
+    types:
+      - closed
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run auto-milestone
+        uses: grafana/grafana-github-actions-go/auto-milestone@main
+        with:
+          pr: ${{ github.event.pull_request.number }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
 ```

--- a/auto-milestone/action.yml
+++ b/auto-milestone/action.yml
@@ -1,0 +1,37 @@
+name: Auto-milestone
+description: Set the milestone of a given PR based on the version of the target branch
+inputs:
+  token:
+    description: GitHub token with access to all necessary repositories
+    required: true
+  pr:
+    description: The PR number that should be updated
+    required: true
+  metrics_api_key:
+    description: API key/password for a Graphite HTTP endpoint
+    required: false
+  metrics_api_username:
+    description: Username for a Graphite HTTP endpoint
+    required: false
+  metrics_api_endpoint:
+    description: Full URL of a Graphite HTTP endpoint
+    required: false
+  binary_release_tag:
+    required: false
+    default: "dev"
+runs:
+  using: composite
+  steps:
+  - run: |
+      set -e
+      # Download the action from the store
+      curl --fail -L -o /tmp/auto-milestone https://github.com/grafana/grafana-github-actions-go/releases/download/${{inputs.binary_release_tag}}/auto-milestone
+      chmod +x /tmp/auto-milestone
+      # Execute action
+      /tmp/auto-milestone ${{inputs.pr}}
+    shell: bash
+    env:
+      GITHUB_TOKEN: ${{inputs.token}}
+      INPUT_METRICS_API_USERNAME: ${{inputs.metrics_api_username}}
+      INPUT_METRICS_API_KEY: ${{inputs.metrics_api_key}}
+      INPUT_METRICS_API_ENDPOINT: ${{inputs.metrics_api_endpoint}}

--- a/auto-milestone/main.go
+++ b/auto-milestone/main.go
@@ -91,7 +91,7 @@ func main() {
 		return
 	}
 	if cnt, err := content.GetContent(); err != nil {
-		logger.Fatal().Err(err).Msg("Failed to retrieve package.json of PR base")
+		logger.Fatal().Err(err).Msg("Failed to get package.json content")
 		return
 	} else {
 		if v, err := versionFromPackage(cnt); err != nil {
@@ -127,14 +127,14 @@ func main() {
 	case actionTypeSetToMilestone:
 		logger.Info().Msgf("Updating PR to %s", a.Milestone)
 		if a.Milestone != nil {
-			if _, _, err := gh.Issues.Edit(ctx, repoOwner, repoName, prNumber, &github.IssueRequest{
+			if _, resp, err := gh.Issues.Edit(ctx, repoOwner, repoName, prNumber, &github.IssueRequest{
 				Milestone: &a.Milestone.Number,
-			}); err != nil {
+			}); err != nil || resp.StatusCode >= 300 {
 				logger.Fatal().Err(err).Msgf("Failed to update #%d with new milestone", prNumber)
 				return
 			}
 		} else {
-			if _, _, err := gh.Issues.RemoveMilestone(ctx, repoOwner, repoName, prNumber); err != nil {
+			if _, resp, err := gh.Issues.RemoveMilestone(ctx, repoOwner, repoName, prNumber); err != nil || resp.StatusCode >= 300 {
 				logger.Fatal().Err(err).Msgf("Failed to remove milestone from #%d", prNumber)
 				return
 			}

--- a/auto-milestone/main.go
+++ b/auto-milestone/main.go
@@ -59,6 +59,11 @@ func main() {
 		tk.ShowInputList()
 		return
 	}
+	defer func() {
+		if err := tk.SubmitUsageMetrics(ctx); err != nil {
+			logger.Warn().Err(err).Msg("Failed to submit usage metrics")
+		}
+	}()
 
 	elems := strings.Split(repo, "/")
 	repoOwner := elems[0]

--- a/auto-milestone/main.go
+++ b/auto-milestone/main.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/google/go-github/v50/github"
+	"github.com/grafana/grafana-github-actions-go/pkg/toolkit"
+	"github.com/rs/zerolog"
+	"github.com/spf13/pflag"
+)
+
+func main() {
+	logger := zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr}).With().Timestamp().Logger()
+	ctx := context.Background()
+	ctx, cancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+	ctx = logger.WithContext(ctx)
+
+	var repo string
+	var doPreview bool
+	var listInputs bool
+	var prNumber int
+
+	pflag.StringVar(&repo, "repo", os.Getenv("GITHUB_REPOSITORY"), "owner/repo pair for a repository on GitHub")
+	pflag.BoolVar(&doPreview, "preview", false, "Only determine the milestone but don't set it")
+	pflag.BoolVar(&listInputs, "list-inputs", false, "Show a list of all available inputs")
+	pflag.Parse()
+
+	rawPRNumber := pflag.Arg(0)
+	if rawPRNumber == "" {
+		logger.Fatal().Msg("No PR specified")
+		return
+	}
+	if parsed, err := strconv.ParseInt(rawPRNumber, 10, 32); err != nil {
+		logger.Fatal().Err(err).Msg("Failed to parse PR number")
+		return
+	} else {
+		prNumber = int(parsed)
+	}
+
+	// Determine the base-branch of that pull request
+	tk, err := toolkit.Init(
+		ctx,
+	)
+	if err != nil {
+		logger.Fatal().Err(err).Msg("Failed to initialize toolkit")
+	}
+
+	if listInputs {
+		tk.ShowInputList()
+		return
+	}
+
+	elems := strings.Split(repo, "/")
+	repoOwner := elems[0]
+	repoName := elems[1]
+
+	gh := tk.GitHubClient()
+
+	pr, _, err := gh.PullRequests.Get(ctx, repoOwner, repoName, prNumber)
+	if err != nil {
+		logger.Fatal().Err(err).Msg("Failed to fetch pull-request")
+	}
+	prTargetBranch := pr.GetBase()
+	if prTargetBranch == nil {
+		logger.Fatal().Msg("The requested pull-request has no target branch")
+		return
+	}
+
+	var targetMilestoneName string
+
+	content, _, _, err := gh.Repositories.GetContents(ctx, prTargetBranch.GetRepo().GetOwner().GetLogin(), prTargetBranch.GetRepo().GetName(), "package.json", &github.RepositoryContentGetOptions{Ref: prTargetBranch.GetRef()})
+	if err != nil {
+		logger.Fatal().Err(err).Msg("Failed to retrieve package.json of PR base")
+		return
+	}
+	if cnt, err := content.GetContent(); err != nil {
+		logger.Fatal().Err(err).Msg("Failed to retrieve package.json of PR base")
+		return
+	} else {
+		if v, err := versionFromPackage(cnt); err != nil {
+			logger.Fatal().Err(err).Msg("Failed to determine base version")
+			return
+		} else {
+			targetMilestoneName = v
+		}
+	}
+
+	logger.Info().Msgf("Target milestone name: %s", targetMilestoneName)
+	milestone, err := tk.GitHubGQLClient().GetMilestoneByTitle(ctx, repoOwner, repoName, targetMilestoneName)
+	if err != nil {
+		logger.Fatal().Msgf("Failed to find milestone matching `%s`", targetMilestoneName)
+	}
+	logger.Info().Msgf("Milestone number: %d", milestone.Number)
+	if doPreview {
+		return
+	}
+
+	// TODO: Check if the PR has a milestone. If it does and matches the one we
+	// picked, there's nothing to do. Otherwise overwrite that milestone.
+}
+
+type packageJSON struct {
+	Version string `json:"version"`
+}
+
+var versionPattern = regexp.MustCompile(`^(\d+)\.(\d+).(\d+)`)
+
+func versionFromPackage(content string) (string, error) {
+	pjson := packageJSON{}
+	if err := json.Unmarshal([]byte(content), &pjson); err != nil {
+		return "", err
+	}
+	v := pjson.Version
+	match := versionPattern.FindStringSubmatch(v)
+	if len(match) < 4 {
+		return "", fmt.Errorf("unsupported version format")
+	}
+	return fmt.Sprintf("%s.%s.x", match[1], match[2]), nil
+}

--- a/auto-milestone/main_test.go
+++ b/auto-milestone/main_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"context"
 	"testing"
 
+	"github.com/google/go-github/v50/github"
+	"github.com/grafana/grafana-github-actions-go/pkg/ghgql"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,6 +52,66 @@ func TestVersionExtraction(t *testing.T) {
 				t.Fatalf("missing expected error")
 			}
 			require.Equal(t, test.expectOutput, v)
+		})
+	}
+}
+
+func TestDetermineAction(t *testing.T) {
+	v10xTitle := "10.0.x"
+	v10Title := "10.0.0"
+	tests := []struct {
+		name             string
+		currentMilestone *github.Milestone
+		targetMilestone  *ghgql.Milestone
+		expected         action
+	}{
+		{
+			name:             "no-milestone-set",
+			currentMilestone: nil,
+			targetMilestone:  &ghgql.Milestone{Title: "10.0.x"},
+			expected: action{
+				Type:      actionTypeSetToMilestone,
+				Milestone: &ghgql.Milestone{Title: "10.0.x"},
+			},
+		},
+		{
+			name: "milestone-correct",
+			currentMilestone: &github.Milestone{
+				Title: &v10xTitle,
+			},
+			targetMilestone: &ghgql.Milestone{Title: "10.0.x"},
+			expected: action{
+				Type: actionTypeNoop,
+			},
+		},
+		{
+			name: "milestone-incorrect",
+			currentMilestone: &github.Milestone{
+				Title: &v10xTitle,
+			},
+			targetMilestone: &ghgql.Milestone{Title: "10.1.x"},
+			expected: action{
+				Type:      actionTypeSetToMilestone,
+				Milestone: &ghgql.Milestone{Title: "10.1.x"},
+			},
+		},
+		{
+			name: "release-milestone-set",
+			currentMilestone: &github.Milestone{
+				Title: &v10Title,
+			},
+			targetMilestone: &ghgql.Milestone{Title: "10.0.x"},
+			expected: action{
+				Type: actionTypeNoop,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			output := determineAction(ctx, test.currentMilestone, test.targetMilestone)
+			require.Equal(t, test.expected, output)
 		})
 	}
 }

--- a/auto-milestone/main_test.go
+++ b/auto-milestone/main_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionExtraction(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		expectErr    bool
+		expectOutput string
+	}{
+		{
+			name:         "valid",
+			input:        `{"version": "10.1.0-pre"}`,
+			expectErr:    false,
+			expectOutput: "10.1.x",
+		},
+		{
+			name:         "no-field",
+			input:        `{}`,
+			expectErr:    true,
+			expectOutput: "",
+		},
+		{
+			name:         "invalid-version",
+			input:        `{"version": "hello"}`,
+			expectErr:    true,
+			expectOutput: "",
+		},
+		{
+			name:         "not-json",
+			input:        `hello`,
+			expectErr:    true,
+			expectOutput: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			v, err := versionFromPackage(test.input)
+			if err != nil && !test.expectErr {
+				t.Fatalf("unexpected error: %s", err.Error())
+			}
+			if err == nil && test.expectErr {
+				t.Fatalf("missing expected error")
+			}
+			require.Equal(t, test.expectOutput, v)
+		})
+	}
+}

--- a/ci/main.go
+++ b/ci/main.go
@@ -13,7 +13,10 @@ import (
 )
 
 func main() {
-	actions := []string{"update-changelog"}
+	actions := []string{
+		"update-changelog",
+		"auto-milestone",
+	}
 
 	var doTest bool
 	var doBuild bool
@@ -39,10 +42,10 @@ func main() {
 
 	goModCache := client.CacheVolume("gomodcache")
 
-	goContainer := client.Container(dagger.ContainerOpts{
-		Platform: "linux/amd64",
-	}).From("golang:1.20.2").
+	goContainer := client.Container().From("golang:1.20.2").
 		WithEnvVariable("CGO_ENABLED", "0").
+		WithEnvVariable("GOOS", "linux").
+		WithEnvVariable("GOARCH", "amd64").
 		WithMountedDirectory("/src", srcDir).
 		WithMountedCache("/go/pkg/mod", goModCache).
 		WithWorkdir("/src")

--- a/ci/main.go
+++ b/ci/main.go
@@ -12,6 +12,8 @@ import (
 	"github.com/spf13/pflag"
 )
 
+const goImage = "golang:1.20.6"
+
 func main() {
 	actions := []string{
 		"update-changelog",
@@ -42,7 +44,7 @@ func main() {
 
 	goModCache := client.CacheVolume("gomodcache")
 
-	goContainer := client.Container().From("golang:1.20.2").
+	goContainer := client.Container().From(goImage).
 		WithEnvVariable("CGO_ENABLED", "0").
 		WithEnvVariable("GOOS", "linux").
 		WithEnvVariable("GOARCH", "amd64").

--- a/pkg/ghgql/generated.go
+++ b/pkg/ghgql/generated.go
@@ -30,6 +30,22 @@ func (v *__getMilestonedPullRequestsInput) GetMilestoneNumber() int { return v.M
 // GetCursor returns __getMilestonedPullRequestsInput.Cursor, and is useful for accessing the field via an interface.
 func (v *__getMilestonedPullRequestsInput) GetCursor() string { return v.Cursor }
 
+// __getMilestonesWithTitleInput is used internally by genqlient
+type __getMilestonesWithTitleInput struct {
+	Owner string `json:"owner"`
+	Repo  string `json:"repo"`
+	Title string `json:"title"`
+}
+
+// GetOwner returns __getMilestonesWithTitleInput.Owner, and is useful for accessing the field via an interface.
+func (v *__getMilestonesWithTitleInput) GetOwner() string { return v.Owner }
+
+// GetRepo returns __getMilestonesWithTitleInput.Repo, and is useful for accessing the field via an interface.
+func (v *__getMilestonesWithTitleInput) GetRepo() string { return v.Repo }
+
+// GetTitle returns __getMilestonesWithTitleInput.Title, and is useful for accessing the field via an interface.
+func (v *__getMilestonesWithTitleInput) GetTitle() string { return v.Title }
+
 // getMilestonedPullRequestsRepository includes the requested fields of the GraphQL type Repository.
 // The GraphQL type's documentation follows.
 //
@@ -529,6 +545,79 @@ func (v *getMilestonedPullRequestsResponse) GetRepository() getMilestonedPullReq
 	return v.Repository
 }
 
+// getMilestonesWithTitleRepository includes the requested fields of the GraphQL type Repository.
+// The GraphQL type's documentation follows.
+//
+// A repository contains the content for a project.
+type getMilestonesWithTitleRepository struct {
+	// A list of milestones associated with the repository.
+	Milestones getMilestonesWithTitleRepositoryMilestonesMilestoneConnection `json:"milestones"`
+}
+
+// GetMilestones returns getMilestonesWithTitleRepository.Milestones, and is useful for accessing the field via an interface.
+func (v *getMilestonesWithTitleRepository) GetMilestones() getMilestonesWithTitleRepositoryMilestonesMilestoneConnection {
+	return v.Milestones
+}
+
+// getMilestonesWithTitleRepositoryMilestonesMilestoneConnection includes the requested fields of the GraphQL type MilestoneConnection.
+// The GraphQL type's documentation follows.
+//
+// The connection type for Milestone.
+type getMilestonesWithTitleRepositoryMilestonesMilestoneConnection struct {
+	// A list of nodes.
+	Nodes []getMilestonesWithTitleRepositoryMilestonesMilestoneConnectionNodesMilestone `json:"nodes"`
+}
+
+// GetNodes returns getMilestonesWithTitleRepositoryMilestonesMilestoneConnection.Nodes, and is useful for accessing the field via an interface.
+func (v *getMilestonesWithTitleRepositoryMilestonesMilestoneConnection) GetNodes() []getMilestonesWithTitleRepositoryMilestonesMilestoneConnectionNodesMilestone {
+	return v.Nodes
+}
+
+// getMilestonesWithTitleRepositoryMilestonesMilestoneConnectionNodesMilestone includes the requested fields of the GraphQL type Milestone.
+// The GraphQL type's documentation follows.
+//
+// Represents a Milestone object on a given repository.
+type getMilestonesWithTitleRepositoryMilestonesMilestoneConnectionNodesMilestone struct {
+	// Identifies the number of the milestone.
+	Number int    `json:"number"`
+	Id     string `json:"id"`
+	// Indicates if the object is closed (definition of closed may depend on type)
+	Closed bool `json:"closed"`
+	// Identifies the title of the milestone.
+	Title string `json:"title"`
+}
+
+// GetNumber returns getMilestonesWithTitleRepositoryMilestonesMilestoneConnectionNodesMilestone.Number, and is useful for accessing the field via an interface.
+func (v *getMilestonesWithTitleRepositoryMilestonesMilestoneConnectionNodesMilestone) GetNumber() int {
+	return v.Number
+}
+
+// GetId returns getMilestonesWithTitleRepositoryMilestonesMilestoneConnectionNodesMilestone.Id, and is useful for accessing the field via an interface.
+func (v *getMilestonesWithTitleRepositoryMilestonesMilestoneConnectionNodesMilestone) GetId() string {
+	return v.Id
+}
+
+// GetClosed returns getMilestonesWithTitleRepositoryMilestonesMilestoneConnectionNodesMilestone.Closed, and is useful for accessing the field via an interface.
+func (v *getMilestonesWithTitleRepositoryMilestonesMilestoneConnectionNodesMilestone) GetClosed() bool {
+	return v.Closed
+}
+
+// GetTitle returns getMilestonesWithTitleRepositoryMilestonesMilestoneConnectionNodesMilestone.Title, and is useful for accessing the field via an interface.
+func (v *getMilestonesWithTitleRepositoryMilestonesMilestoneConnectionNodesMilestone) GetTitle() string {
+	return v.Title
+}
+
+// getMilestonesWithTitleResponse is returned by getMilestonesWithTitle on success.
+type getMilestonesWithTitleResponse struct {
+	// Lookup a given repository by the owner and repository name.
+	Repository getMilestonesWithTitleRepository `json:"repository"`
+}
+
+// GetRepository returns getMilestonesWithTitleResponse.Repository, and is useful for accessing the field via an interface.
+func (v *getMilestonesWithTitleResponse) GetRepository() getMilestonesWithTitleRepository {
+	return v.Repository
+}
+
 // The query or mutation executed by getMilestonedPullRequests.
 const getMilestonedPullRequests_Operation = `
 query getMilestonedPullRequests ($owner: String!, $repo: String!, $milestoneNumber: Int!, $cursor: String!) {
@@ -582,6 +671,52 @@ func getMilestonedPullRequests(
 	var err error
 
 	var data getMilestonedPullRequestsResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
+// The query or mutation executed by getMilestonesWithTitle.
+const getMilestonesWithTitle_Operation = `
+query getMilestonesWithTitle ($owner: String!, $repo: String!, $title: String!) {
+	repository(owner: $owner, name: $repo) {
+		milestones(query: $title, first: 30) {
+			nodes {
+				number
+				id
+				closed
+				title
+			}
+		}
+	}
+}
+`
+
+func getMilestonesWithTitle(
+	ctx context.Context,
+	client graphql.Client,
+	owner string,
+	repo string,
+	title string,
+) (*getMilestonesWithTitleResponse, error) {
+	req := &graphql.Request{
+		OpName: "getMilestonesWithTitle",
+		Query:  getMilestonesWithTitle_Operation,
+		Variables: &__getMilestonesWithTitleInput{
+			Owner: owner,
+			Repo:  repo,
+			Title: title,
+		},
+	}
+	var err error
+
+	var data getMilestonesWithTitleResponse
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(

--- a/pkg/ghgql/genqlient.graphql
+++ b/pkg/ghgql/genqlient.graphql
@@ -25,3 +25,16 @@ query getMilestonedPullRequests($owner: String!, $repo: String!, $milestoneNumbe
     }
   }
 }
+
+query getMilestonesWithTitle($owner: String!, $repo: String!, $title: String!) {
+  repository(owner: $owner, name: $repo) {
+    milestones(query: $title, first: 30) {
+      nodes {
+        number
+        id
+        closed
+        title
+      }
+    }
+  }
+}

--- a/pkg/ghgql/milestones.go
+++ b/pkg/ghgql/milestones.go
@@ -1,6 +1,10 @@
 package ghgql
 
-import "context"
+import (
+	"context"
+
+	"github.com/rs/zerolog"
+)
 
 type Milestone struct {
 	Number int
@@ -13,11 +17,13 @@ func (m Milestone) String() string {
 }
 
 func (c *Client) GetMilestoneByTitle(ctx context.Context, repoOwner string, repoName string, title string) (*Milestone, error) {
+	logger := zerolog.Ctx(ctx)
 	resp, err := getMilestonesWithTitle(ctx, c.gql, repoOwner, repoName, title)
 	if err != nil {
 		return nil, err
 	}
 	if resp == nil {
+		logger.Warn().Msgf("No response for milestone with title `%s`", title)
 		return nil, nil
 	}
 	for _, candidate := range resp.GetRepository().Milestones.Nodes {
@@ -29,5 +35,6 @@ func (c *Client) GetMilestoneByTitle(ctx context.Context, repoOwner string, repo
 			}, nil
 		}
 	}
+	logger.Warn().Msgf("No milestone with title `%s` found", title)
 	return nil, nil
 }

--- a/pkg/ghgql/milestones.go
+++ b/pkg/ghgql/milestones.go
@@ -8,6 +8,10 @@ type Milestone struct {
 	Closed bool
 }
 
+func (m Milestone) String() string {
+	return m.Title
+}
+
 func (c *Client) GetMilestoneByTitle(ctx context.Context, repoOwner string, repoName string, title string) (*Milestone, error) {
 	resp, err := getMilestonesWithTitle(ctx, c.gql, repoOwner, repoName, title)
 	if err != nil {

--- a/pkg/ghgql/milestones.go
+++ b/pkg/ghgql/milestones.go
@@ -1,0 +1,29 @@
+package ghgql
+
+import "context"
+
+type Milestone struct {
+	Number int
+	Title  string
+	Closed bool
+}
+
+func (c *Client) GetMilestoneByTitle(ctx context.Context, repoOwner string, repoName string, title string) (*Milestone, error) {
+	resp, err := getMilestonesWithTitle(ctx, c.gql, repoOwner, repoName, title)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, nil
+	}
+	for _, candidate := range resp.GetRepository().Milestones.Nodes {
+		if title == candidate.GetTitle() {
+			return &Milestone{
+				Number: candidate.Number,
+				Title:  candidate.Title,
+				Closed: candidate.Closed,
+			}, nil
+		}
+	}
+	return nil, nil
+}


### PR DESCRIPTION
This new action should help with setting the milestone of a PR in grafana/grafana and related repositories. It detects the target milestone by retrieving the version of the target branch.

- [x] Preview mode which should just print the expected milestone but not update the PR
- [x] Update the PR with the expected milestone
- [x] Handling for the case that a PR already has a release milestone attached
