### PR TITLE
Port of github-release

### DIFF
--- a/ci/main.go
+++ b/ci/main.go
@@ -16,6 +16,7 @@ const goImage = "golang:1.20.6"
 
 func main() {
 	actions := []string{
+		"github-release",
 		"update-changelog",
 		"auto-milestone",
 	}

--- a/github-release/README.md
+++ b/github-release/README.md
@@ -1,0 +1,13 @@
+# github-release
+
+This action allows you to quickly generate a new GitHub released based on the provided version.
+The underlying tag with the same name as the version needs to exist.
+The content of the release will be generated based on the *existing* changelog.
+
+You can also dry-run it using the following command:
+
+```
+$ go run ./github-release --preview --repo grafana/grafana $VERSION
+# e.g. go run ./github-release --preview --repo grafana/grafana 9.4.12
+```
+

--- a/github-release/README.md
+++ b/github-release/README.md
@@ -11,3 +11,27 @@ $ go run ./github-release --preview --repo grafana/grafana $VERSION
 # e.g. go run ./github-release --preview --repo grafana/grafana 9.4.12
 ```
 
+## Example workflow:
+
+```
+name: Create or update GitHub release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        description: Needs to match, exactly, the name of a milestone (NO v prefix)
+      latest:
+        required: false
+        description: Mark the new release as latest (`1` or `0`)
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run github release action
+        uses: grafana/grafana-github-actions-go/auto-milestone@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          metricsWriteAPIKey: ${{secrets.GRAFANA_MISC_STATS_API_KEY}}
+
+```

--- a/github-release/action.yml
+++ b/github-release/action.yml
@@ -1,0 +1,37 @@
+name: GitHub Release
+description: Generates a new release on GitHub for the given version
+inputs:
+  token:
+    description: GitHub token with access to all necessary repositories
+    required: true
+  version:
+    description: The version for which to generate a release
+    required: true
+  metrics_api_key:
+    description: API key/password for a Graphite HTTP endpoint
+    required: false
+  metrics_api_username:
+    description: Username for a Graphite HTTP endpoint
+    required: false
+  metrics_api_endpoint:
+    description: Full URL of a Graphite HTTP endpoint
+    required: false
+  binary_release_tag:
+    required: false
+    default: "dev"
+runs:
+  using: composite
+  steps:
+  - run: |
+      set -e
+      # Download the action from the store
+      curl --fail -L -o /tmp/github-release https://github.com/grafana/grafana-github-actions-go/releases/download/${{inputs.binary_release_tag}}/github-release
+      chmod +x /tmp/github-release
+      # Execute action
+      /tmp/github-release ${{inputs.version}}
+    shell: bash
+    env:
+      GITHUB_TOKEN: ${{inputs.token}}
+      INPUT_METRICS_API_USERNAME: ${{inputs.metrics_api_username}}
+      INPUT_METRICS_API_KEY: ${{inputs.metrics_api_key}}
+      INPUT_METRICS_API_ENDPOINT: ${{inputs.metrics_api_endpoint}}

--- a/github-release/action.yml
+++ b/github-release/action.yml
@@ -19,6 +19,9 @@ inputs:
   binary_release_tag:
     required: false
     default: "dev"
+  latest:
+    description: Mark the release as latest (1 for latest, 0 for not)
+    required: false
 runs:
   using: composite
   steps:
@@ -35,3 +38,4 @@ runs:
       INPUT_METRICS_API_USERNAME: ${{inputs.metrics_api_username}}
       INPUT_METRICS_API_KEY: ${{inputs.metrics_api_key}}
       INPUT_METRICS_API_ENDPOINT: ${{inputs.metrics_api_endpoint}}
+      INPUT_LATEST: ${{inputs.latest}}

--- a/github-release/main.go
+++ b/github-release/main.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/google/go-github/v50/github"
+	"github.com/grafana/grafana-github-actions-go/pkg/changelog"
+	"github.com/grafana/grafana-github-actions-go/pkg/ghgql"
+	"github.com/grafana/grafana-github-actions-go/pkg/toolkit"
+	"github.com/rs/zerolog"
+	"github.com/spf13/pflag"
+)
+
+func main() {
+	logger := zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr}).With().Timestamp().Logger()
+	ctx := context.Background()
+	ctx, cancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+	ctx = logger.WithContext(ctx)
+
+	var repo string
+	var doPreview bool
+	var listInputs bool
+	var version string
+
+	pflag.StringVar(&repo, "repo", os.Getenv("GITHUB_REPOSITORY"), "owner/repo pair for a repository on GitHub")
+	pflag.BoolVar(&doPreview, "preview", false, "Only determine the milestone but don't set it")
+	pflag.BoolVar(&listInputs, "list-inputs", false, "Show a list of all available inputs")
+	pflag.Parse()
+
+	logger.Info().Msgf("Operating inside %s", repo)
+
+	version = pflag.Arg(0)
+	tag := fmt.Sprintf("v%s", version)
+
+	tk, err := toolkit.Init(
+		ctx,
+	)
+	if err != nil {
+		logger.Fatal().Err(err).Msg("Failed to initialize toolkit")
+	}
+
+	if listInputs {
+		tk.ShowInputList()
+		return
+	}
+	defer func() {
+		if err := tk.SubmitUsageMetrics(ctx); err != nil {
+			logger.Warn().Err(err).Msg("Failed to submit usage metrics")
+		}
+	}()
+
+	elems := strings.Split(repo, "/")
+	repoOwner := elems[0]
+	repoName := elems[1]
+
+	gh := tk.GitHubClient()
+
+	tagExists, err := verifyTagExists(ctx, gh, repoOwner, repoName, tag)
+	if err != nil {
+		logger.Fatal().Err(err).Msgf("Failed to verify that tag `%s` exists", version)
+	}
+
+	if !tagExists {
+		logger.Fatal().Err(err).Msgf("Tag `%s` does not exist", version)
+	}
+
+	// We also need the milestone for that release to get the date for the release title:
+	milestone, err := tk.GitHubGQLClient().GetMilestoneByTitle(ctx, repoOwner, repoName, version)
+	if err != nil {
+		logger.Fatal().Err(err).Msgf("No matching milestone found for `%s`", version)
+	}
+
+	changelogContent, err := retrieveChangelog(ctx, gh, repoOwner, repoName, version)
+	if err != nil {
+		logger.Fatal().Err(err).Msgf("Failed to retrieve changelog for %s", version)
+	}
+
+	releaseTitle := generateReleaseTitle(ctx, version, milestone)
+
+	if doPreview {
+		logger.Info().Msgf("No release will be created but this is what it would look like:")
+		fmt.Printf("TITLE: %s\n\n%s\n", releaseTitle, changelogContent)
+		return
+	}
+
+	logger.Info().Msgf("Creating new release.")
+	logger.Fatal().Msg("Creating the release not yet implemented.")
+
+}
+
+func generateReleaseTitle(ctx context.Context, version string, milestone *ghgql.Milestone) string {
+	date := milestone.ClosedAt
+	if !milestone.DueOn.IsZero() {
+		date = milestone.DueOn
+	}
+	return fmt.Sprintf("%s (%s)", version, date.Format("2006-01-02"))
+}
+
+func verifyTagExists(ctx context.Context, gh *github.Client, repoOwner string, repoName string, tag string) (bool, error) {
+	opts := github.ListOptions{}
+	opts.Page = 1
+	for {
+		tags, resp, err := gh.Repositories.ListTags(ctx, repoOwner, repoName, &opts)
+		if err != nil {
+			return false, err
+		}
+		for _, t := range tags {
+			if t.GetName() == tag {
+				return true, nil
+			}
+		}
+		if resp.NextPage <= opts.Page {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return false, nil
+}
+
+func retrieveChangelog(ctx context.Context, gh *github.Client, repoOwner string, repoName string, version string) (string, error) {
+	loader := changelog.NewLoader(gh)
+	output, err := loader.LoadContent(ctx, repoOwner, repoName, version, &changelog.LoaderOptions{
+		RemoveHeading: true,
+	})
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(`[Download page](https://grafana.com/grafana/download/%s)
+[What's new highlights](https://grafana.com/docs/grafana/latest/whatsnew/)
+
+%s`, version, output), nil
+}

--- a/github-release/main_test.go
+++ b/github-release/main_test.go
@@ -1,0 +1,1 @@
+package main

--- a/pkg/changelog/loader.go
+++ b/pkg/changelog/loader.go
@@ -1,0 +1,117 @@
+package changelog
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/google/go-github/v50/github"
+	"github.com/rs/zerolog"
+)
+
+type LoaderOptions struct {
+	RemoveHeading bool
+}
+
+// Loader can be used to retrieve an existing changelog from a GitHub
+// repository structed similar to grafana/grafana.
+type Loader struct {
+	gh *github.Client
+}
+
+func NewLoader(gh *github.Client) *Loader {
+	return &Loader{
+		gh: gh,
+	}
+}
+
+func (l *Loader) LoadContent(ctx context.Context, repoOwner string, repoName string, version string, opts *LoaderOptions) (string, error) {
+	logger := zerolog.Ctx(ctx)
+	vel := strings.Split(strings.TrimPrefix(version, "v"), ".")
+	if len(vel) < 1 {
+		return "", fmt.Errorf("unsupported version provided")
+	}
+	majorVersion := vel[0]
+	fileCandidates := []string{
+		"CHANGELOG.md",
+		fmt.Sprintf(".changelog-archive/CHANGELOG.%s.md", majorVersion),
+	}
+	for _, clPath := range fileCandidates {
+		fc, _, resp, err := l.gh.Repositories.GetContents(ctx, repoOwner, repoName, clPath, nil)
+		if resp.StatusCode == http.StatusNotFound {
+			logger.Warn().Msgf("Changelog file not found: %s", clPath)
+			continue
+		}
+		if err != nil {
+			return "", err
+		}
+		rawContent, err := fc.GetContent()
+		if err != nil {
+			return "", err
+		}
+		buf := bytes.NewBufferString(rawContent)
+		clContent, found, err := ExtractContentForVersion(ctx, buf, version, &ExtractContentOptions{
+			RemoveHeadling: opts.RemoveHeading,
+		})
+		if err != nil {
+			return "", err
+		}
+		if found {
+			return clContent, nil
+		}
+	}
+
+	return "", fmt.Errorf("no changelog found")
+}
+
+type ExtractContentOptions struct {
+	RemoveHeadling bool
+}
+
+// ExtractContentForVersion parses the provided fileContent for the content of
+// a specific version and returns it if present.
+func ExtractContentForVersion(ctx context.Context, fileContent io.Reader, version string, options *ExtractContentOptions) (string, bool, error) {
+	opts := options
+	if opts == nil {
+		opts = &ExtractContentOptions{
+			RemoveHeadling: false,
+		}
+	}
+	v := strings.TrimPrefix(version, "v")
+	output := strings.Builder{}
+	sc := bufio.NewScanner(fileContent)
+	sc.Split(bufio.ScanLines)
+	inVersion := false
+	versionStart := fmt.Sprintf("<!-- %s START -->", v)
+	versionEnd := fmt.Sprintf("<!-- %s END -->", v)
+	nonEmptyLines := 0
+	for sc.Scan() {
+		line := sc.Text()
+		if !inVersion && line == versionStart {
+			inVersion = true
+			continue
+		}
+		if inVersion {
+			if line == versionEnd {
+				result := strings.TrimSpace(output.String())
+				return result, true, nil
+			}
+			// Remove the first non-empty line that starts with a # if
+			// requested:
+			if opts.RemoveHeadling && strings.HasPrefix(line, "# ") && nonEmptyLines == 0 {
+				continue
+			}
+			output.WriteString(line)
+			output.WriteRune('\n')
+			if line != "" {
+				nonEmptyLines += 1
+			}
+		}
+
+	}
+	return output.String(), false, nil
+}

--- a/pkg/changelog/loader_test.go
+++ b/pkg/changelog/loader_test.go
@@ -1,0 +1,79 @@
+package changelog
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractContentForVersion(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		version        string
+		opts           *ExtractContentOptions
+		expectedOutput string
+		expectedFound  bool
+		expectedError  bool
+	}{
+		{
+			name:           "empty input",
+			version:        "v1.2.3",
+			input:          "",
+			expectedOutput: "",
+			expectedFound:  false,
+			expectedError:  false,
+		},
+		{
+			name:           "content present without heading somewhere in the file",
+			version:        "v1.2.3",
+			input:          "<!-- 1.2.2 START -->\nwrong content\n<!-- 1.2.2 END -->\n<!-- 1.2.3 START -->\ncontent\n<!-- 1.2.3 END -->\n<!-- 1.2.4 START -->\nwrong content\n<!-- 1.2.4 END -->",
+			expectedOutput: "content",
+			expectedFound:  true,
+			expectedError:  false,
+		},
+		{
+			name:           "content present without heading",
+			version:        "v1.2.3",
+			input:          "<!-- 1.2.3 START -->\ncontent\n<!-- 1.2.3 END -->",
+			expectedOutput: "content",
+			expectedFound:  true,
+			expectedError:  false,
+		},
+		{
+			name:    "content present with heading removed",
+			version: "v1.2.3",
+			input:   "<!-- 1.2.3 START -->\n\n\n# 1.2.3 (2023-07-08)\n\ncontent\n<!-- 1.2.3 END -->",
+			opts: &ExtractContentOptions{
+				RemoveHeadling: true,
+			},
+			expectedOutput: "content",
+			expectedFound:  true,
+			expectedError:  false,
+		},
+		{
+			name:           "content present with multiple lines",
+			version:        "v1.2.3",
+			input:          "<!-- 1.2.3 START -->\ncontent\nsecond line\n<!-- 1.2.3 END -->",
+			expectedOutput: "content\nsecond line",
+			expectedFound:  true,
+			expectedError:  false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			output, found, err := ExtractContentForVersion(ctx, bytes.NewBufferString(test.input), test.version, test.opts)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.expectedFound, found)
+				require.Equal(t, test.expectedOutput, output)
+			}
+		})
+	}
+}

--- a/pkg/ghgql/generated.go
+++ b/pkg/ghgql/generated.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/Khan/genqlient/graphql"
 )
@@ -585,6 +586,10 @@ type getMilestonesWithTitleRepositoryMilestonesMilestoneConnectionNodesMilestone
 	Closed bool `json:"closed"`
 	// Identifies the title of the milestone.
 	Title string `json:"title"`
+	// Identifies the date and time when the object was closed.
+	ClosedAt time.Time `json:"closedAt"`
+	// Identifies the due date of the milestone.
+	DueOn time.Time `json:"dueOn"`
 }
 
 // GetNumber returns getMilestonesWithTitleRepositoryMilestonesMilestoneConnectionNodesMilestone.Number, and is useful for accessing the field via an interface.
@@ -605,6 +610,16 @@ func (v *getMilestonesWithTitleRepositoryMilestonesMilestoneConnectionNodesMiles
 // GetTitle returns getMilestonesWithTitleRepositoryMilestonesMilestoneConnectionNodesMilestone.Title, and is useful for accessing the field via an interface.
 func (v *getMilestonesWithTitleRepositoryMilestonesMilestoneConnectionNodesMilestone) GetTitle() string {
 	return v.Title
+}
+
+// GetClosedAt returns getMilestonesWithTitleRepositoryMilestonesMilestoneConnectionNodesMilestone.ClosedAt, and is useful for accessing the field via an interface.
+func (v *getMilestonesWithTitleRepositoryMilestonesMilestoneConnectionNodesMilestone) GetClosedAt() time.Time {
+	return v.ClosedAt
+}
+
+// GetDueOn returns getMilestonesWithTitleRepositoryMilestonesMilestoneConnectionNodesMilestone.DueOn, and is useful for accessing the field via an interface.
+func (v *getMilestonesWithTitleRepositoryMilestonesMilestoneConnectionNodesMilestone) GetDueOn() time.Time {
+	return v.DueOn
 }
 
 // getMilestonesWithTitleResponse is returned by getMilestonesWithTitle on success.
@@ -692,6 +707,8 @@ query getMilestonesWithTitle ($owner: String!, $repo: String!, $title: String!) 
 				id
 				closed
 				title
+				closedAt
+				dueOn
 			}
 		}
 	}

--- a/pkg/ghgql/genqlient.graphql
+++ b/pkg/ghgql/genqlient.graphql
@@ -34,6 +34,8 @@ query getMilestonesWithTitle($owner: String!, $repo: String!, $title: String!) {
         id
         closed
         title
+        closedAt
+        dueOn
       }
     }
   }

--- a/pkg/ghgql/genqlient.yaml
+++ b/pkg/ghgql/genqlient.yaml
@@ -7,3 +7,5 @@ generated: generated.go
 bindings:
   URI:
     type: string
+  DateTime:
+    type: "time.Time"

--- a/pkg/ghgql/milestones.go
+++ b/pkg/ghgql/milestones.go
@@ -2,14 +2,17 @@ package ghgql
 
 import (
 	"context"
+	"time"
 
 	"github.com/rs/zerolog"
 )
 
 type Milestone struct {
-	Number int
-	Title  string
-	Closed bool
+	Number   int
+	Title    string
+	Closed   bool
+	ClosedAt time.Time
+	DueOn    time.Time
 }
 
 func (m Milestone) String() string {
@@ -29,9 +32,11 @@ func (c *Client) GetMilestoneByTitle(ctx context.Context, repoOwner string, repo
 	for _, candidate := range resp.GetRepository().Milestones.Nodes {
 		if title == candidate.GetTitle() {
 			return &Milestone{
-				Number: candidate.Number,
-				Title:  candidate.Title,
-				Closed: candidate.Closed,
+				Number:   candidate.Number,
+				Title:    candidate.Title,
+				Closed:   candidate.Closed,
+				ClosedAt: candidate.ClosedAt,
+				DueOn:    candidate.DueOn,
 			}, nil
 		}
 	}


### PR DESCRIPTION
This adds a new `github-release` action based on what we had with https://github.com/grafana/grafana-github-actions/tree/97f88bd80dd8b59c674e2bfdf19acfa60a6b3dcc/github-release but with a few changes:

- The body of the release still contains the changelog but it only takes what is in the CHANGELOG.md file already created in a previous release step. This should prevent inconsistencies between the two.
- A new release won't be considered "latest" by default. Use `-f latest=1` when running the workflow. This will help us with multiple public releases happening at the same time where we only want one of them to be considered "latest".

This `latest` flag need to be provided explicitly as we have no easy way to find out what the actual latest release is supposed to be at the time this is executed. The release guide needs to be updated accordingly.


TODOs:

- [x] Implement preview mode
- [x] Implement `latest` flag
- [x] Implement creation of the milestone
- [x] Make the operation idempotent so that reruns will not create a new milestone but update an existing one

Fixes #48