### PR TITLE
Add community-release action

### DIFF
--- a/ci/main.go
+++ b/ci/main.go
@@ -19,6 +19,7 @@ func main() {
 		"github-release",
 		"update-changelog",
 		"auto-milestone",
+		"community-release",
 	}
 
 	var doTest bool

--- a/community-release/README.md
+++ b/community-release/README.md
@@ -1,0 +1,34 @@
+# community-release
+
+This action allows you to quickly generate a new release post on https://community.grafana.com/ based on the changelog for the provided version.
+
+You can also dry-run it using the following command:
+
+```
+$ INPUT_VERSION=... go run ./community-release --preview --repo grafana/grafana
+# e.g. INPUT_VERSION=9.4.12 go run ./community-release --preview --repo grafana/grafana
+```
+
+## Example workflow:
+
+```
+name: Create or update GitHub release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        description: Needs to match, exactly, the name of a milestone (NO v prefix)
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run github release action
+        uses: grafana/grafana-github-actions-go/community-release@main
+        with:
+          version: ${{ inputs.version }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          metricsWriteAPIKey: ${{secrets.GRAFANA_MISC_STATS_API_KEY}}
+          community_api_key: ${{ secrets.COMMUNITY_API_KEY }}
+          community_api_username:${{ secrets.COMMUNITY_USERNAME }}
+```

--- a/community-release/action.yml
+++ b/community-release/action.yml
@@ -1,0 +1,52 @@
+name: GitHub Release
+description: Generates a new release on GitHub for the given version
+inputs:
+  token:
+    description: GitHub token with access to all necessary repositories
+    required: true
+  version:
+    description: The version for which to generate a release
+    required: true
+  community_api_username:
+    required: true
+  community_api_key:
+    required: true
+  community_base_url:
+    required: false
+    default: "https://community.grafana.com"
+  community_category_id:
+    required: false
+    default: "9"
+  metrics_api_key:
+    description: API key/password for a Graphite HTTP endpoint
+    required: false
+  metrics_api_username:
+    description: Username for a Graphite HTTP endpoint
+    required: false
+  metrics_api_endpoint:
+    description: Full URL of a Graphite HTTP endpoint
+    required: false
+  binary_release_tag:
+    required: false
+    default: "dev"
+runs:
+  using: composite
+  steps:
+  - run: |
+      set -e
+      # Download the action from the store
+      curl --fail -L -o /tmp/community-release https://github.com/grafana/grafana-github-actions-go/releases/download/${{inputs.binary_release_tag}}/community-release
+      chmod +x /tmp/community-release
+      # Execute action
+      /tmp/community-release
+    shell: bash
+    env:
+      GITHUB_TOKEN: ${{inputs.token}}
+      INPUT_VERSION: ${{inputs.version}}
+      INPUT_METRICS_API_USERNAME: ${{inputs.metrics_api_username}}
+      INPUT_METRICS_API_KEY: ${{inputs.metrics_api_key}}
+      INPUT_METRICS_API_ENDPOINT: ${{inputs.metrics_api_endpoint}}
+      INPUT_COMMUNITY_API_USERNAME: ${{inputs.community_api_username}}
+      INPUT_COMMUNITY_API_KEY: ${{inputs.community_api_key}}
+      INPUT_COMMUNITY_BASE_URL: ${{inputs.community_base_url}}
+      INPUT_COMMUNITY_CATEGORY_ID: ${{inputs.community_category_id}}

--- a/community-release/main.go
+++ b/community-release/main.go
@@ -114,13 +114,14 @@ func main() {
 		logger.Fatal().Err(err).Msgf("Failed to parse %s", tk.GetInputEnvName(inputCommunityCategoryID))
 	}
 
-	logger.Info().Msg("Posting to the community boards")
+	logger.Info().Msgf("Posting to the community board in category %d", communityCategoryID)
 	comm := community.New(
 		community.CommunityWithBaseURL(communityBaseURL),
 		community.CommunityWithAPICredentials(username, key),
 	)
 	if _, err := comm.CreateOrUpdatePost(ctx, community.PostInput{
 		Title:    fmt.Sprintf("Changelog: Updates in Grafana %s", version),
+		Author:   username,
 		Body:     changelogContent,
 		Category: communityCategoryID,
 	}); err != nil {

--- a/community-release/main.go
+++ b/community-release/main.go
@@ -22,6 +22,8 @@ const inputCommunityAPIUsername = "COMMUNITY_API_USERNAME"
 const inputCommunityCategoryID = "COMMUNITY_CATEGORY_ID"
 const inputCommunityBaseURL = "COMMUNITY_BASE_URL"
 const inputVersion = "VERSION"
+const defaultCategoryID = "9"
+const defaultBaseURL = "https://community.grafana.com/"
 
 func main() {
 	logger := zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr}).With().Timestamp().Logger()
@@ -104,10 +106,10 @@ func main() {
 		logger.Fatal().Msgf("No %s provided", tk.GetInputEnvName(inputCommunityAPIUsername))
 	}
 	if communityBaseURL == "" {
-		communityBaseURL = "https://community.grafana.com/"
+		communityBaseURL = defaultBaseURL
 	}
 	if rawCommunityCategoryID == "" {
-		rawCommunityCategoryID = "9"
+		rawCommunityCategoryID = defaultCategoryID
 	}
 	communityCategoryID, err := strconv.Atoi(rawCommunityCategoryID)
 	if err != nil {

--- a/community-release/main.go
+++ b/community-release/main.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/google/go-github/v50/github"
+	"github.com/grafana/grafana-github-actions-go/pkg/changelog"
+	"github.com/grafana/grafana-github-actions-go/pkg/community"
+	"github.com/grafana/grafana-github-actions-go/pkg/toolkit"
+	"github.com/rs/zerolog"
+	"github.com/spf13/pflag"
+)
+
+const inputCommunityAPIKey = "COMMUNITY_API_KEY"
+const inputCommunityAPIUsername = "COMMUNITY_API_USERNAME"
+const inputCommunityCategoryID = "COMMUNITY_CATEGORY_ID"
+const inputCommunityBaseURL = "COMMUNITY_BASE_URL"
+const inputVersion = "VERSION"
+
+func main() {
+	logger := zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr}).With().Timestamp().Logger()
+	ctx := context.Background()
+	ctx, cancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+	ctx = logger.WithContext(ctx)
+
+	var repo string
+	var doPreview bool
+	var listInputs bool
+
+	pflag.StringVar(&repo, "repo", os.Getenv("GITHUB_REPOSITORY"), "owner/repo pair for a repository on GitHub")
+	pflag.BoolVar(&doPreview, "preview", false, "Only determine the milestone but don't set it")
+	pflag.BoolVar(&listInputs, "list-inputs", false, "Show a list of all available inputs")
+	pflag.Parse()
+
+	logger.Info().Msgf("Operating inside %s", repo)
+
+	tk, err := toolkit.Init(
+		ctx,
+		toolkit.WithRegisteredInput(inputVersion, "Version number to generate the changelog for"),
+		toolkit.WithRegisteredInput(inputCommunityAPIKey, "API token for the Discourse community"),
+		toolkit.WithRegisteredInput(inputCommunityAPIUsername, "API username for the Discourse community"),
+		toolkit.WithRegisteredInput(inputCommunityCategoryID, "Discourse category ID for the changelog post"),
+		toolkit.WithRegisteredInput(inputCommunityBaseURL, "URL where the Discourse community can be found"),
+	)
+	if err != nil {
+		logger.Fatal().Err(err).Msg("Failed to initialize toolkit")
+	}
+
+	if listInputs {
+		tk.ShowInputList()
+		return
+	}
+	defer func() {
+		if err := tk.SubmitUsageMetrics(ctx); err != nil {
+			logger.Warn().Err(err).Msg("Failed to submit usage metrics")
+		}
+	}()
+
+	version := tk.MustGetInput(ctx, inputVersion)
+
+	elems := strings.Split(repo, "/")
+	repoOwner := elems[0]
+	repoName := elems[1]
+
+	gh := tk.GitHubClient()
+
+	// We also need the milestone for that release to get the date for the release title:
+	milestone, err := tk.GitHubGQLClient().GetMilestoneByTitle(ctx, repoOwner, repoName, version)
+	if err != nil {
+		logger.Fatal().Err(err).Msgf("No matching milestone found for `%s`", version)
+	}
+	if milestone == nil {
+		logger.Fatal().Msgf("No matching milestone found for `%s`", version)
+	}
+
+	changelogContent, err := retrieveChangelog(ctx, gh, repoOwner, repoName, version)
+	if err != nil {
+		logger.Fatal().Err(err).Msgf("Failed to retrieve changelog for %s", version)
+	}
+
+	releaseTitle := fmt.Sprintf("Changelog: Updates in Grafana %s", version)
+
+	if doPreview {
+		logger.Info().Msgf("No post will be created but this is what it would look like:")
+		fmt.Printf("TITLE: %s\n\n%s\n", releaseTitle, changelogContent)
+		return
+	}
+
+	key := tk.MustGetInput(ctx, inputCommunityAPIKey)
+	username := tk.MustGetInput(ctx, inputCommunityAPIUsername)
+	communityBaseURL := tk.MustGetInput(ctx, inputCommunityBaseURL)
+	rawCommunityCategoryID := tk.MustGetInput(ctx, inputCommunityCategoryID)
+	if key == "" {
+		logger.Fatal().Msgf("No %s provided", tk.GetInputEnvName(inputCommunityAPIKey))
+	}
+	if username == "" {
+		logger.Fatal().Msgf("No %s provided", tk.GetInputEnvName(inputCommunityAPIUsername))
+	}
+	if communityBaseURL == "" {
+		communityBaseURL = "https://community.grafana.com/"
+	}
+	if rawCommunityCategoryID == "" {
+		rawCommunityCategoryID = "9"
+	}
+	communityCategoryID, err := strconv.Atoi(rawCommunityCategoryID)
+	if err != nil {
+		logger.Fatal().Err(err).Msgf("Failed to parse %s", tk.GetInputEnvName(inputCommunityCategoryID))
+	}
+
+	logger.Info().Msg("Posting to the community boards")
+	comm := community.New(
+		community.CommunityWithBaseURL(communityBaseURL),
+		community.CommunityWithAPICredentials(username, key),
+	)
+	if _, err := comm.CreateOrUpdatePost(ctx, community.PostInput{
+		Title:    fmt.Sprintf("Changelog: Updates in Grafana %s", version),
+		Body:     changelogContent,
+		Category: communityCategoryID,
+	}); err != nil {
+		logger.Fatal().Err(err).Msg("Failed to post to the forums")
+	}
+
+}
+
+func retrieveChangelog(ctx context.Context, gh *github.Client, repoOwner string, repoName string, version string) (string, error) {
+	loader := changelog.NewLoader(gh)
+	output, err := loader.LoadContent(ctx, repoOwner, repoName, version, &changelog.LoaderOptions{
+		RemoveHeading: true,
+	})
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(`%s
+
+[Download page](https://grafana.com/grafana/download/%s)
+[What's new highlights](https://grafana.com/docs/grafana/latest/whatsnew/)`, output, version), nil
+}

--- a/community-release/main_test.go
+++ b/community-release/main_test.go
@@ -1,0 +1,1 @@
+package main

--- a/pkg/community/community.go
+++ b/pkg/community/community.go
@@ -47,7 +47,7 @@ func (c *Community) CreateOrUpdatePost(ctx context.Context, post PostInput) (int
 	if err != nil {
 		return -1, err
 	}
-	searchQuery := fmt.Sprintf("%s @%s #%s in:title order:latest_topic", post.Title, post.Author, category.Slug)
+	searchQuery := fmt.Sprintf("%s @%s #%s in:title order:latest_topic", post.Title, post.Author, category.Category.Slug)
 	opts := SearchOptions{
 		Page: 1,
 	}
@@ -133,9 +133,15 @@ func (c *Community) getCategory(ctx context.Context, id int) (*Category, error) 
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
 	defer resp.Body.Close()
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, err
+	}
+	if result.Category.ID == 0 {
+		return nil, fmt.Errorf("failed to decode category API data (no ID returned)")
 	}
 	return &result, nil
 }

--- a/pkg/community/search.go
+++ b/pkg/community/search.go
@@ -21,8 +21,10 @@ type Post struct {
 }
 
 type Category struct {
-	ID   int    `json:"id"`
-	Slug string `json:"slug"`
+	Category struct {
+		ID   int    `json:"id"`
+		Slug string `json:"slug"`
+	} `json:"category"`
 }
 
 type SearchOptions struct {


### PR DESCRIPTION
This implements the same functionality as the community post part of the update-changelog action. That other implementation is kept in place to make migrating less risky.

Part of https://github.com/grafana/grafana-delivery/issues/200