### PR TITLE
Add codeowners-validator similar to grafana/grafana

### DIFF
--- a/.github/workflows/codeowners-validator.yml
+++ b/.github/workflows/codeowners-validator.yml
@@ -1,0 +1,38 @@
+name: "Codeowners Validator"
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  codeowners-validator:
+    runs-on: ubuntu-latest
+    steps:
+      # Checks-out your repository, which is validated in the next step
+      - uses: actions/checkout@v2
+      - name: GitHub CODEOWNERS Validator
+        uses: mszostok/codeowners-validator@v0.7.4
+        # input parameters
+        with:
+          # ==== GitHub Auth ====
+
+          # "The list of checks that will be executed. By default, all checks are executed. Possible values: files,owners,duppatterns,syntax"
+          checks: "files,duppatterns,syntax"
+
+          # "The comma-separated list of experimental checks that should be executed. By default, all experimental checks are turned off. Possible values: notowned,avoid-shadowing"
+          experimental_checks: "notowned,avoid-shadowing"
+          
+          # The repository path in which CODEOWNERS file should be validated."
+          repository_path: "."
+
+          # Defines the level on which the application should treat check issues as failures. Defaults to warning, which treats both errors and warnings as failures, and exits with error code 3. Possible values are error and warning. Default: warning"
+          check_failure_level: "error"
+
+          # The comma-separated list of patterns that should be ignored by not-owned-checker. For example, you can specify * and as a result, the * pattern from the CODEOWNERS file will be ignored and files owned by this pattern will be reported as unowned unless a later specific pattern will match that path. It's useful because often we have default owners entry at the begging of the CODOEWNERS file, e.g. * @global-owner1 @global-owner2"
+          not_owned_checker_skip_patterns: ""
+
+          # Specifies whether CODEOWNERS may have unowned files. For example, `/infra/oncall-rotator/oncall-config.yml` doesn't have owner and this is not reported.
+          owner_checker_allow_unowned_patterns: "false"
+
+          # Specifies whether only teams are allowed as owners of files.
+          owner_checker_owners_must_be_teams: "false"          


### PR DESCRIPTION
This should prevent invalid CODEOWNER configurations so that reviewers can always be assigned appropriately.