### PR TITLE
Community-release: Handling of 422 errors

### DIFF
--- a/community-release/main.go
+++ b/community-release/main.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"unicode/utf8"
 
 	"github.com/google/go-github/v50/github"
 	"github.com/grafana/grafana-github-actions-go/pkg/changelog"
@@ -87,6 +88,8 @@ func main() {
 		logger.Fatal().Err(err).Msgf("Failed to retrieve changelog for %s", version)
 	}
 
+	logger.Info().Msgf("Changelog received with %d characters", utf8.RuneCountInString(changelogContent))
+
 	releaseTitle := fmt.Sprintf("Changelog: Updates in Grafana %s", version)
 
 	if doPreview {
@@ -126,6 +129,8 @@ func main() {
 		Author:   username,
 		Body:     changelogContent,
 		Category: communityCategoryID,
+	}, &community.PostOptions{
+		FallbackBody: changelogFooter(version),
 	}); err != nil {
 		logger.Fatal().Err(err).Msg("Failed to post to the forums")
 	}
@@ -142,6 +147,10 @@ func retrieveChangelog(ctx context.Context, gh *github.Client, repoOwner string,
 	}
 	return fmt.Sprintf(`%s
 
-[Download page](https://grafana.com/grafana/download/%s)
-[What's new highlights](https://grafana.com/docs/grafana/latest/whatsnew/)`, output, version), nil
+%s`, output, changelogFooter(version)), nil
+}
+
+func changelogFooter(version string) string {
+	return fmt.Sprintf(`[Download page](https://grafana.com/grafana/download/%s)
+[What's new highlights](https://grafana.com/docs/grafana/latest/whatsnew/)`, version)
 }

--- a/community-release/main.go
+++ b/community-release/main.go
@@ -125,12 +125,12 @@ func main() {
 		community.CommunityWithAPICredentials(username, key),
 	)
 	if _, err := comm.CreateOrUpdatePost(ctx, community.PostInput{
-		Title:    fmt.Sprintf("Changelog: Updates in Grafana %s", version),
+		Title:    releaseTitle,
 		Author:   username,
 		Body:     changelogContent,
 		Category: communityCategoryID,
 	}, &community.PostOptions{
-		FallbackBody: changelogFooter(version),
+		FallbackBody: fallbackChangelog(version),
 	}); err != nil {
 		logger.Fatal().Err(err).Msg("Failed to post to the forums")
 	}
@@ -153,4 +153,9 @@ func retrieveChangelog(ctx context.Context, gh *github.Client, repoOwner string,
 func changelogFooter(version string) string {
 	return fmt.Sprintf(`[Download page](https://grafana.com/grafana/download/%s)
 [What's new highlights](https://grafana.com/docs/grafana/latest/whatsnew/)`, version)
+}
+
+func fallbackChangelog(version string) string {
+	return fmt.Sprintf(`[Full changelog](https://github.com/grafana/grafana/releases/tag/v%s)
+%s`, version, changelogFooter(version))
 }

--- a/pkg/community/community.go
+++ b/pkg/community/community.go
@@ -18,12 +18,12 @@ type Community struct {
 	key        string
 	username   string
 	baseURL    string
-	httpClient http.Client
+	httpClient *http.Client
 }
 
 func New(options ...CommunityOption) *Community {
 	c := &Community{
-		httpClient: http.Client{},
+		httpClient: &http.Client{},
 	}
 	for _, opt := range options {
 		opt(c)
@@ -38,14 +38,22 @@ type PostInput struct {
 	Author   string `json:"-"`
 }
 
+type PostOptions struct {
+	// FallbackBody is used for situations where the server returns a size-limit error.
+	FallbackBody string
+}
+
 // CreateOrUpdate tries to update an existing post with the provided title in
 // the specified category. If no such topic exists, a new topic with the same
 // content will be created.
-func (c *Community) CreateOrUpdatePost(ctx context.Context, post PostInput) (int, error) {
+func (c *Community) CreateOrUpdatePost(ctx context.Context, post PostInput, postOpts *PostOptions) (int, error) {
+	if postOpts == nil {
+		postOpts = &PostOptions{}
+	}
 	logger := zerolog.Ctx(ctx)
 	category, err := c.getCategory(ctx, post.Category)
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to retrieve category: %w", err)
 	}
 	searchQuery := fmt.Sprintf("%s @%s #%s in:title order:latest_topic", post.Title, post.Author, category.Category.Slug)
 	opts := SearchOptions{
@@ -58,15 +66,33 @@ func (c *Community) CreateOrUpdatePost(ctx context.Context, post PostInput) (int
 	if len(result.Posts) > 0 {
 		// No post found, so let's create a new one
 		logger.Info().Msgf("Updating post %d", result.Posts[0].ID)
-		return result.Posts[0].ID, c.updatePost(ctx, result.Posts[0].ID, post.Body)
+		if err := c.updatePost(ctx, result.Posts[0].ID, post.Body); err != nil {
+			if err == errPostTooLong {
+				if err := c.updatePost(ctx, result.Posts[0].ID, postOpts.FallbackBody); err != nil {
+					return result.Posts[0].ID, err
+				}
+				return result.Posts[0].ID, nil
+			}
+			return result.Posts[0].ID, err
+		}
+		return result.Posts[0].ID, nil
 	}
 
 	topic, err := c.createTopic(ctx, post)
 	if err != nil {
+		if err == errPostTooLong {
+			post.Body = postOpts.FallbackBody
+			topic, err = c.createTopic(ctx, post)
+			if err != nil {
+				return -1, err
+			}
+		}
 		return -1, err
 	}
 	return topic.ID, nil
 }
+
+var errPostTooLong = fmt.Errorf("post content is too long")
 
 func (c *Community) createTopic(ctx context.Context, post PostInput) (*Post, error) {
 	body := bytes.Buffer{}
@@ -87,7 +113,10 @@ func (c *Community) createTopic(ctx context.Context, post PostInput) (*Post, err
 
 	if resp.StatusCode != http.StatusOK {
 		io.Copy(os.Stderr, resp.Body)
-		return nil, fmt.Errorf("creating a new post failed")
+		if resp.StatusCode == http.StatusUnprocessableEntity {
+			return nil, errPostTooLong
+		}
+		return nil, fmt.Errorf("creating a new post failed with status code %d", resp.StatusCode)
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, err
@@ -118,7 +147,10 @@ func (c *Community) updatePost(ctx context.Context, postID int, raw string) erro
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		io.Copy(os.Stderr, resp.Body)
-		return fmt.Errorf("unexpected status code %d", resp.StatusCode)
+		if resp.StatusCode == http.StatusUnprocessableEntity {
+			return errPostTooLong
+		}
+		return fmt.Errorf("updating existing post failed with status code %d", resp.StatusCode)
 	}
 	return nil
 }

--- a/pkg/community/community.go
+++ b/pkg/community/community.go
@@ -112,10 +112,10 @@ func (c *Community) createTopic(ctx context.Context, post PostInput) (*Post, err
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		io.Copy(os.Stderr, resp.Body)
 		if resp.StatusCode == http.StatusUnprocessableEntity {
 			return nil, errPostTooLong
 		}
+		io.Copy(os.Stderr, resp.Body)
 		return nil, fmt.Errorf("creating a new post failed with status code %d", resp.StatusCode)
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
@@ -146,10 +146,10 @@ func (c *Community) updatePost(ctx context.Context, postID int, raw string) erro
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		io.Copy(os.Stderr, resp.Body)
 		if resp.StatusCode == http.StatusUnprocessableEntity {
 			return errPostTooLong
 		}
+		io.Copy(os.Stderr, resp.Body)
 		return fmt.Errorf("updating existing post failed with status code %d", resp.StatusCode)
 	}
 	return nil

--- a/pkg/community/options.go
+++ b/pkg/community/options.go
@@ -1,5 +1,7 @@
 package community
 
+import "net/http"
+
 type CommunityOption func(c *Community)
 
 func CommunityWithBaseURL(u string) CommunityOption {
@@ -12,5 +14,11 @@ func CommunityWithAPICredentials(username, key string) CommunityOption {
 	return func(c *Community) {
 		c.key = key
 		c.username = username
+	}
+}
+
+func CommunityWithHTTPClient(client *http.Client) CommunityOption {
+	return func(c *Community) {
+		c.httpClient = client
 	}
 }

--- a/pkg/community/post_test.go
+++ b/pkg/community/post_test.go
@@ -1,0 +1,159 @@
+package community
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommunityPost(t *testing.T) {
+	t.Run("too-much-content-create", func(t *testing.T) {
+		// If the changelog is larger than 50000 characters, then the server
+		// will respond with an error code 422 and the following message:
+		//
+		// `{"action":"create_post","errors":["Body is limited to 50000 characters; you entered [...]."]}`
+		//
+		// In such a situation, the client should try again with a shorter
+		// message.
+		ctx := context.Background()
+		srv := NewMockCommunityServer()
+		comm := New(CommunityWithBaseURL(srv.GetURL()), CommunityWithHTTPClient(srv.GetClient()))
+
+		// This produces a string with 50005 characters, which will go beyond
+		// the size limit:
+		body := strings.Repeat("hello", 10001)
+		_, err := comm.CreateOrUpdatePost(ctx, PostInput{
+			Title:    "Sample Post",
+			Category: 4,
+			Body:     body,
+			Author:   "test",
+		}, &PostOptions{
+			FallbackBody: "fallback",
+		})
+		require.NoError(t, err)
+		postCalls := srv.GetPostCalls()
+		require.Len(t, postCalls, 2)
+		require.Equal(t, "fallback", postCalls[1].Raw)
+	})
+
+	t.Run("too-much-content-update", func(t *testing.T) {
+		// Same as the previous test but for updating an existing post.
+		ctx := context.Background()
+		srv := NewMockCommunityServer()
+		srv.ExistingPosts = []TestSearchPost{
+			{
+				ID:      1,
+				TopicID: 1,
+			},
+		}
+		comm := New(CommunityWithBaseURL(srv.GetURL()), CommunityWithHTTPClient(srv.GetClient()))
+		body := strings.Repeat("hello", 10001)
+		_, err := comm.CreateOrUpdatePost(ctx, PostInput{
+			Title:    "Sample Post",
+			Category: 4,
+			Body:     body,
+			Author:   "test",
+		}, &PostOptions{
+			FallbackBody: "fallback",
+		})
+		require.NoError(t, err)
+		postCalls := srv.GetPostCalls()
+		require.Len(t, postCalls, 2)
+		require.Equal(t, "fallback", postCalls[1].Raw)
+	})
+}
+
+type TestPost struct {
+	Title    string
+	Raw      string
+	Category int
+	Author   string
+}
+type TestPostUpdate struct {
+	Post struct {
+		Raw string
+	}
+}
+
+type TestSearchPost struct {
+	ID      int `json:"id"`
+	TopicID int `json:"topic_id"`
+}
+
+type MockCommunityServer struct {
+	srv           *httptest.Server
+	PostSizeLimit int
+	ExistingPosts []TestSearchPost
+	postCalls     []TestPost
+}
+
+func NewMockCommunityServer() *MockCommunityServer {
+	s := MockCommunityServer{
+		PostSizeLimit: 50000,
+		postCalls:     make([]TestPost, 0, 5),
+	}
+	handler := http.NewServeMux()
+	handler.HandleFunc("/c/4/show.json", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"category": {"id": 4, "slug": "hello"}}`)
+	})
+	handler.HandleFunc("/search.json", func(w http.ResponseWriter, r *http.Request) {
+		data := map[string]interface{}{
+			"posts": s.ExistingPosts,
+		}
+		json.NewEncoder(w).Encode(data)
+	})
+	handler.HandleFunc("/posts.json", func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		post := TestPost{}
+		if err := json.NewDecoder(r.Body).Decode(&post); err != nil {
+			http.Error(w, "Decoding failed", http.StatusInternalServerError)
+			return
+		}
+		s.postCalls = append(s.postCalls, post)
+		if size := utf8.RuneCountInString(post.Raw); size > s.PostSizeLimit {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			fmt.Fprintf(w, `{"action":"create_post","errors":["Body is limited to %d characters; you entered %d."]}`, s.PostSizeLimit, size)
+			return
+		}
+		fmt.Fprintf(w, `{}`)
+	})
+	handler.HandleFunc("/posts/1.json", func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		post := TestPostUpdate{}
+		if err := json.NewDecoder(r.Body).Decode(&post); err != nil {
+			http.Error(w, "Decoding failed", http.StatusInternalServerError)
+			return
+		}
+		s.postCalls = append(s.postCalls, TestPost{
+			Raw: post.Post.Raw,
+		})
+		if size := utf8.RuneCountInString(post.Post.Raw); size > s.PostSizeLimit {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			fmt.Fprintf(w, `{"action":"create_post","errors":["Body is limited to %d characters; you entered %d."]}`, s.PostSizeLimit, size)
+			return
+		}
+		fmt.Fprintf(w, `{}`)
+	})
+	srv := httptest.NewServer(handler)
+	s.srv = srv
+	return &s
+}
+
+func (m *MockCommunityServer) GetPostCalls() []TestPost {
+	return m.postCalls
+}
+
+func (m *MockCommunityServer) GetURL() string {
+	return m.srv.URL
+}
+
+func (m *MockCommunityServer) GetClient() *http.Client {
+	return m.srv.Client()
+}


### PR DESCRIPTION
When the post body is too long then the action now only posts a link to the changelog:

```
[Full changelog](...)
[Download link](...)
[What's new](...)
```

Closes #60 