### PR TITLE
chore: Add release-guild as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @grafana/grafana-delivery
+* @grafana/grafana-delivery @grafana/grafana-release-guild


### PR DESCRIPTION
Part of https://github.com/grafana/grafana-delivery/issues/280