### PR TITLE
Chore: only add a milestone for PRs targeting main or .x branches

### DIFF
--- a/auto-milestone/main.go
+++ b/auto-milestone/main.go
@@ -193,7 +193,7 @@ func determineAction(ctx context.Context, pr *github.PullRequest, currentMilesto
 	}
 	prTargetBranchLabel := pr.GetBase().GetLabel()
 	if prTargetBranchLabel != "main" && !strings.HasSuffix(prTargetBranchLabel, ".x") {
-		logger.Info().Msg(fmt.Sprintf("The PR is targeting branch %s, which does not match either main or a release branch. No action required.", prTargetBranchLabel))
+		logger.Info().Msgf("The PR is targeting branch %s, which does not match either main or a release branch. No action required.", prTargetBranchLabel)
 		return action{
 			Type: actionTypeNoop,
 		}

--- a/auto-milestone/main.go
+++ b/auto-milestone/main.go
@@ -191,6 +191,13 @@ func determineAction(ctx context.Context, pr *github.PullRequest, currentMilesto
 			}
 		}
 	}
+	prTargetBranchLabel := pr.GetBase().GetLabel()
+	if prTargetBranchLabel != "main" && !strings.HasSuffix(prTargetBranchLabel, ".x") {
+		logger.Info().Msg("The requested pull-request is not targetting main or a release branch. No action required.")
+		return action{
+			Type: actionTypeNoop,
+		}
+	}
 	if currentMilestone == nil {
 		return action{
 			Type:      actionTypeSetToMilestone,

--- a/auto-milestone/main.go
+++ b/auto-milestone/main.go
@@ -193,7 +193,7 @@ func determineAction(ctx context.Context, pr *github.PullRequest, currentMilesto
 	}
 	prTargetBranchLabel := pr.GetBase().GetLabel()
 	if prTargetBranchLabel != "main" && !strings.HasSuffix(prTargetBranchLabel, ".x") {
-		logger.Info().Msg("The requested pull-request is not targetting main or a release branch. No action required.")
+		logger.Info().Msg(fmt.Sprintf("The PR is targeting branch %s, which does not match either main or a release branch. No action required.", prTargetBranchLabel))
 		return action{
 			Type: actionTypeNoop,
 		}

--- a/auto-milestone/main_test.go
+++ b/auto-milestone/main_test.go
@@ -60,6 +60,8 @@ func TestVersionExtraction(t *testing.T) {
 func TestDetermineAction(t *testing.T) {
 	v10xTitle := "10.0.x"
 	v10Title := "10.0.0"
+	releaseBaseTitle := "main"
+	notReleaseBaseTitle := "notMainOrReleaseBranch"
 	valFalse := false
 	valTrue := true
 	valPastTimestamp := github.Timestamp{
@@ -77,6 +79,9 @@ func TestDetermineAction(t *testing.T) {
 			pr: &github.PullRequest{
 				ClosedAt: &valPastTimestamp,
 				Merged:   &valTrue,
+				Base: &github.PullRequestBranch{
+					Label: &releaseBaseTitle,
+				},
 			},
 			currentMilestone: nil,
 			targetMilestone:  &ghgql.Milestone{Title: "10.0.x"},
@@ -86,10 +91,28 @@ func TestDetermineAction(t *testing.T) {
 			},
 		},
 		{
+			name: "no-milestone-set-non-release-branch",
+			pr: &github.PullRequest{
+				ClosedAt: &valPastTimestamp,
+				Merged:   &valTrue,
+				Base: &github.PullRequestBranch{
+					Label: &notReleaseBaseTitle,
+				},
+			},
+			currentMilestone: nil,
+			targetMilestone:  &ghgql.Milestone{Title: "10.0.x"},
+			expected: action{
+				Type: actionTypeNoop,
+			},
+		},
+		{
 			name: "milestone-correct",
 			pr: &github.PullRequest{
 				ClosedAt: &valPastTimestamp,
 				Merged:   &valTrue,
+				Base: &github.PullRequestBranch{
+					Label: &releaseBaseTitle,
+				},
 			},
 			currentMilestone: &github.Milestone{
 				Title: &v10xTitle,
@@ -104,6 +127,9 @@ func TestDetermineAction(t *testing.T) {
 			pr: &github.PullRequest{
 				ClosedAt: &valPastTimestamp,
 				Merged:   &valTrue,
+				Base: &github.PullRequestBranch{
+					Label: &releaseBaseTitle,
+				},
 			},
 			currentMilestone: &github.Milestone{
 				Title: &v10xTitle,
@@ -119,6 +145,9 @@ func TestDetermineAction(t *testing.T) {
 			pr: &github.PullRequest{
 				ClosedAt: &valPastTimestamp,
 				Merged:   &valFalse,
+				Base: &github.PullRequestBranch{
+					Label: &releaseBaseTitle,
+				},
 			},
 			currentMilestone: &github.Milestone{
 				Title: &v10xTitle,
@@ -134,6 +163,9 @@ func TestDetermineAction(t *testing.T) {
 			pr: &github.PullRequest{
 				ClosedAt: &valPastTimestamp,
 				Merged:   &valTrue,
+				Base: &github.PullRequestBranch{
+					Label: &releaseBaseTitle,
+				},
 			},
 			currentMilestone: &github.Milestone{
 				Title: &v10Title,


### PR DESCRIPTION
- modifies the `determineAction` function
- if the base branch isn't either `main` or `<something>.x`, then do nothing and log a message

Fixes https://github.com/grafana/grafana/issues/77973