### PR TITLE
Automilestone: adjust main label to match what's actually returned by the api

### DIFF
--- a/auto-milestone/main.go
+++ b/auto-milestone/main.go
@@ -192,7 +192,7 @@ func determineAction(ctx context.Context, pr *github.PullRequest, currentMilesto
 		}
 	}
 	prTargetBranchLabel := pr.GetBase().GetLabel()
-	if prTargetBranchLabel != "main" && !strings.HasSuffix(prTargetBranchLabel, ".x") {
+	if prTargetBranchLabel != "grafana:main" && !strings.HasSuffix(prTargetBranchLabel, ".x") {
 		logger.Info().Msgf("The PR is targeting branch %s, which does not match either main or a release branch. No action required.", prTargetBranchLabel)
 		return action{
 			Type: actionTypeNoop,

--- a/auto-milestone/main_test.go
+++ b/auto-milestone/main_test.go
@@ -60,8 +60,8 @@ func TestVersionExtraction(t *testing.T) {
 func TestDetermineAction(t *testing.T) {
 	v10xTitle := "10.0.x"
 	v10Title := "10.0.0"
-	releaseBaseTitle := "main"
-	notReleaseBaseTitle := "notMainOrReleaseBranch"
+	releaseBaseTitle := "grafana:main"
+	notReleaseBaseTitle := "grafana:notMainOrReleaseBranch"
 	valFalse := false
 	valTrue := true
 	valPastTimestamp := github.Timestamp{


### PR DESCRIPTION
- adjusts the main label to match what's returned by the api
- see the logs [here](https://github.com/grafana/grafana/actions/runs/7561170498/job/20588836193):
```
8:05PM INF Target milestone name: 10.4.x
8:05PM INF The PR is targeting branch grafana:main, which does not match either main or a release branch. No action required.
8:05PM INF No action necessary.
```
- follow up to https://github.com/grafana/grafana-github-actions-go/pull/93