### PR TITLE
Refactor and add tests for github-release

### DIFF
--- a/github-release/create_release.go
+++ b/github-release/create_release.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/google/go-github/v50/github"
+)
+
+type ReleaseCreator interface {
+	ListTags(ctx context.Context, owner string, repo string, opts *github.ListOptions) ([]*github.RepositoryTag, *github.Response, error)
+	CreateRelease(ctx context.Context, owner, repo string, release *github.RepositoryRelease) (*github.RepositoryRelease, *github.Response, error)
+	GetReleaseByTag(ctx context.Context, owner, repo, tag string) (*github.RepositoryRelease, *github.Response, error)
+	EditRelease(ctx context.Context, owner, repo string, id int64, release *github.RepositoryRelease) (*github.RepositoryRelease, *github.Response, error)
+}
+
+func CreateRelease(ctx context.Context, client ReleaseCreator, owner, repo, tag string, release *github.RepositoryRelease) (string, error) {
+	tagExists, err := verifyTagExists(ctx, client, owner, repo, tag)
+	if err != nil {
+		return "", fmt.Errorf("failed to verify tag exists: %w", err)
+	}
+
+	if !tagExists {
+		return "", fmt.Errorf("tag `%s` does not exist", tag)
+	}
+
+	rel, resp, err := client.GetReleaseByTag(ctx, owner, repo, tag)
+	if err != nil {
+		if resp.StatusCode != http.StatusNotFound {
+			return "", fmt.Errorf("failed to check for existing release: %w", err)
+		}
+	}
+
+	if rel != nil {
+		rel.Name = release.Name
+		rel.Body = release.Body
+		rel.MakeLatest = release.MakeLatest
+
+		r, _, err := client.EditRelease(ctx, owner, repo, rel.GetID(), rel)
+		if err != nil {
+			return "", fmt.Errorf("failed to update existing release: %w", err)
+		}
+
+		return r.GetHTMLURL(), nil
+	}
+
+	rel, _, err = client.CreateRelease(ctx, owner, repo, release)
+	if err != nil {
+		return "", err
+	}
+
+	return "", nil
+}
+
+func verifyTagExists(ctx context.Context, client ReleaseCreator, owner string, repo string, tag string) (bool, error) {
+	opts := github.ListOptions{}
+	opts.Page = 1
+	for {
+		tags, resp, err := client.ListTags(ctx, owner, repo, &opts)
+		if err != nil {
+			return false, err
+		}
+		for _, t := range tags {
+			if t.GetName() == tag {
+				return true, nil
+			}
+		}
+		if resp.NextPage <= opts.Page {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return false, nil
+}

--- a/github-release/create_release_test.go
+++ b/github-release/create_release_test.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-github/v50/github"
+)
+
+type TestReleaseCreator struct {
+	ListTagsFunc        func(ctx context.Context, owner string, repo string, opts *github.ListOptions) ([]*github.RepositoryTag, *github.Response, error)
+	CreateReleaseFunc   func(ctx context.Context, owner, repo string, release *github.RepositoryRelease) (*github.RepositoryRelease, *github.Response, error)
+	GetReleaseByTagFunc func(ctx context.Context, owner, repo, tag string) (*github.RepositoryRelease, *github.Response, error)
+	EditReleaseFunc     func(ctx context.Context, owner, repo string, id int64, release *github.RepositoryRelease) (*github.RepositoryRelease, *github.Response, error)
+}
+
+func (c *TestReleaseCreator) ListTags(ctx context.Context, owner string, repo string, opts *github.ListOptions) ([]*github.RepositoryTag, *github.Response, error) {
+	return c.ListTagsFunc(ctx, owner, repo, opts)
+}
+
+func (c *TestReleaseCreator) CreateRelease(ctx context.Context, owner, repo string, release *github.RepositoryRelease) (*github.RepositoryRelease, *github.Response, error) {
+	return c.CreateReleaseFunc(ctx, owner, repo, release)
+}
+
+func (c *TestReleaseCreator) GetReleaseByTag(ctx context.Context, owner, repo, tag string) (*github.RepositoryRelease, *github.Response, error) {
+	return c.GetReleaseByTagFunc(ctx, owner, repo, tag)
+}
+
+func (c *TestReleaseCreator) EditRelease(ctx context.Context, owner, repo string, id int64, release *github.RepositoryRelease) (*github.RepositoryRelease, *github.Response, error) {
+	return c.EditReleaseFunc(ctx, owner, repo, id, release)
+}
+
+func TestCreateRelease(t *testing.T) {
+	ctx := context.Background()
+
+	listTagsFunc := func(ctx context.Context, owner string, repo string, opts *github.ListOptions) ([]*github.RepositoryTag, *github.Response, error) {
+		return []*github.RepositoryTag{
+				{
+					Name: github.String("v1.2.3"),
+				},
+				{
+					Name: github.String("v1.2.3+security-01"),
+				},
+				{
+					Name: github.String("v1.2.4"),
+				},
+			}, &github.Response{
+				NextPage: 0,
+			}, nil
+	}
+
+	createReleaseFunc := func(ctx context.Context, owner, repo string, release *github.RepositoryRelease) (*github.RepositoryRelease, *github.Response, error) {
+		return release, nil, nil
+	}
+
+	getReleaseByTagFunc := func(ctx context.Context, owner, repo, tag string) (*github.RepositoryRelease, *github.Response, error) {
+		return &github.RepositoryRelease{
+			TagName: github.String(tag),
+		}, nil, nil
+	}
+
+	editReleaseFunc := func(ctx context.Context, owner, repo string, id int64, release *github.RepositoryRelease) (*github.RepositoryRelease, *github.Response, error) {
+		return &github.RepositoryRelease{
+			ID:      github.Int64(id),
+			TagName: release.TagName,
+			Name:    release.Name,
+			Body:    release.Body,
+		}, nil, nil
+	}
+
+	t.Run("It should return an error if the tag doesn't exist", func(t *testing.T) {
+		client := &TestReleaseCreator{
+			ListTagsFunc:        listTagsFunc,
+			CreateReleaseFunc:   createReleaseFunc,
+			GetReleaseByTagFunc: getReleaseByTagFunc,
+			EditReleaseFunc:     editReleaseFunc,
+		}
+
+		_, err := CreateRelease(ctx, client, "grafana", "grafana", "v3.2.1", &github.RepositoryRelease{})
+		if err == nil {
+			t.Fatal("CreateRelease should return an error if the tag does not exist in the repo")
+		}
+	})
+
+	t.Run("It should create a github release if one doesn't exist", func(t *testing.T) {
+		created := false
+		edited := false
+		client := &TestReleaseCreator{
+			ListTagsFunc: listTagsFunc,
+			CreateReleaseFunc: func(ctx context.Context, owner, repo string, release *github.RepositoryRelease) (*github.RepositoryRelease, *github.Response, error) {
+				created = true
+				return release, nil, nil
+			},
+			GetReleaseByTagFunc: func(ctx context.Context, owner, repo, tag string) (*github.RepositoryRelease, *github.Response, error) {
+				return nil, &github.Response{
+					Response: &http.Response{
+						StatusCode: http.StatusNotFound,
+					},
+				}, nil
+			},
+			EditReleaseFunc: func(ctx context.Context, owner, repo string, id int64, release *github.RepositoryRelease) (*github.RepositoryRelease, *github.Response, error) {
+				edited = true
+				return nil, nil, nil
+			},
+		}
+
+		_, err := CreateRelease(ctx, client, "grafana", "grafana", "v1.2.3", &github.RepositoryRelease{
+			MakeLatest: LatestString(true),
+		})
+		if err != nil {
+			t.Fatal("CreateRelease should not return an error; error: ", err)
+		}
+
+		if !created {
+			t.Fatal("CreateRelease not called")
+		}
+		if edited {
+			t.Fatal("EditRelease should not be called")
+		}
+	})
+
+	t.Run("It should edit a github release if one does exist", func(t *testing.T) {
+		created := false
+		edited := false
+		client := &TestReleaseCreator{
+			ListTagsFunc: listTagsFunc,
+			CreateReleaseFunc: func(ctx context.Context, owner, repo string, release *github.RepositoryRelease) (*github.RepositoryRelease, *github.Response, error) {
+				created = true
+				return release, nil, nil
+			},
+			GetReleaseByTagFunc: func(ctx context.Context, owner, repo, tag string) (*github.RepositoryRelease, *github.Response, error) {
+				return &github.RepositoryRelease{
+						Name:    github.String(tag),
+						TagName: github.String(tag),
+					}, &github.Response{
+						Response: &http.Response{
+							StatusCode: http.StatusOK,
+						},
+					}, nil
+			},
+			EditReleaseFunc: func(ctx context.Context, owner, repo string, id int64, release *github.RepositoryRelease) (*github.RepositoryRelease, *github.Response, error) {
+				edited = true
+				return release, nil, nil
+			},
+		}
+
+		_, err := CreateRelease(ctx, client, "grafana", "grafana", "v1.2.3", &github.RepositoryRelease{
+			MakeLatest: LatestString(true),
+		})
+		if err != nil {
+			t.Fatal("CreateRelease should not return an error; error: ", err)
+		}
+
+		if created {
+			t.Fatal("CreateRelease should not be called")
+		}
+
+		if !edited {
+			t.Fatal("EditRelease was not called")
+		}
+	})
+}

--- a/github-release/main.go
+++ b/github-release/main.go
@@ -3,44 +3,47 @@ package main
 import (
 	"context"
 	"fmt"
-	"net/http"
+	"log/slog"
 	"os"
 	"os/signal"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/google/go-github/v50/github"
 	"github.com/grafana/grafana-github-actions-go/pkg/changelog"
-	"github.com/grafana/grafana-github-actions-go/pkg/ghgql"
 	"github.com/grafana/grafana-github-actions-go/pkg/toolkit"
-	"github.com/rs/zerolog"
 	"github.com/spf13/pflag"
 )
 
-var makeLatestTrue = "true"
-var makeLatestFalse = "false"
+// LatestString returns a string that the GitHub API expects.
+// Their docs say that this string can be one of: "true", "false", or "legacy".
+func LatestString(latest bool) *string {
+	if latest {
+		return github.String("true")
+	}
+
+	return github.String("false")
+}
 
 func main() {
-	logger := zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr}).With().Timestamp().Logger()
+	log := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	ctx := context.Background()
 	ctx, cancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
-	ctx = logger.WithContext(ctx)
 
-	var repo string
+	var ownerRepo string
 	var doPreview bool
 	var listInputs bool
 	var version string
 
-	pflag.StringVar(&repo, "repo", os.Getenv("GITHUB_REPOSITORY"), "owner/repo pair for a repository on GitHub")
+	pflag.StringVar(&ownerRepo, "repo", os.Getenv("GITHUB_REPOSITORY"), "owner/repo pair for a repository on GitHub")
 	pflag.BoolVar(&doPreview, "preview", false, "Only determine the milestone but don't set it")
 	pflag.BoolVar(&listInputs, "list-inputs", false, "Show a list of all available inputs")
 	pflag.Parse()
 
-	logger.Info().Msgf("Operating inside %s", repo)
+	log.Info("starting GitHub release")
 
-	version = pflag.Arg(0)
+	version = strings.TrimPrefix(pflag.Arg(0), "v")
 	tag := fmt.Sprintf("v%s", version)
 
 	tk, err := toolkit.Init(
@@ -48,7 +51,8 @@ func main() {
 		toolkit.WithRegisteredInput("latest", "`true` for marking the release as latest, otherwise not"),
 	)
 	if err != nil {
-		logger.Fatal().Err(err).Msg("Failed to initialize toolkit")
+		log.Error("failed to initialize toolkit", "error", err)
+		panic("failed to initialize toolkit")
 	}
 
 	if listInputs {
@@ -57,117 +61,50 @@ func main() {
 	}
 	defer func() {
 		if err := tk.SubmitUsageMetrics(ctx); err != nil {
-			logger.Warn().Err(err).Msg("Failed to submit usage metrics")
+			log.Warn("failed to submit usage metrics", "error", err)
 		}
 	}()
 
-	markLatest := tk.MustGetBoolInput(ctx, "latest")
+	log = log.With("tag", tag, "repo", ownerRepo)
+	latest := tk.MustGetBoolInput(ctx, "latest")
 
-	elems := strings.Split(repo, "/")
-	repoOwner := elems[0]
-	repoName := elems[1]
+	elems := strings.Split(ownerRepo, "/")
+	owner := elems[0]
+	repo := elems[1]
 
 	gh := tk.GitHubClient()
 
-	tagExists, err := verifyTagExists(ctx, gh, repoOwner, repoName, tag)
+	changelogContent, err := retrieveChangelog(ctx, gh, owner, repo, version)
 	if err != nil {
-		logger.Fatal().Err(err).Msgf("Failed to verify that tag `%s` exists", version)
-	}
-
-	if !tagExists {
-		logger.Fatal().Err(err).Msgf("Tag `%s` does not exist", version)
-	}
-
-	changelogContent, err := retrieveChangelog(ctx, gh, repoOwner, repoName, version)
-	if err != nil {
-		logger.Fatal().Err(err).Msgf("Failed to retrieve changelog for %s", version)
+		panic(fmt.Sprintf("failed to retrieve changelog for %s", version))
 	}
 
 	releaseTitle := version
 
-	existingRelease, resp, err := gh.Repositories.GetReleaseByTag(ctx, repoOwner, repoName, tag)
-	if err != nil {
-		if resp.StatusCode == http.StatusNotFound {
-			logger.Info().Msgf("No existing release found for tag `%s`", tag)
-		} else {
-			logger.Fatal().Err(err).Msgf("Failed to check for existing release with tag `%s`", tag)
-		}
-	}
-
 	if doPreview {
-		logger.Info().Msgf("No release will be created but this is what it would look like:")
+		fmt.Println("no release will be created but this is what it would look like:")
 		fmt.Printf("TITLE: %s\n\n%s\n", releaseTitle, changelogContent)
 		return
 	}
 
-	if existingRelease != nil {
-		logger.Info().Msgf("Updating existing release")
-		existingRelease.Name = &releaseTitle
-		existingRelease.Body = &changelogContent
-		if markLatest {
-			existingRelease.MakeLatest = &makeLatestTrue
-		} else {
-			existingRelease.MakeLatest = &makeLatestFalse
-		}
-		if rel, _, err := gh.Repositories.EditRelease(ctx, repoOwner, repoName, existingRelease.GetID(), existingRelease); err != nil {
-			logger.Fatal().Err(err).Msgf("Failed to update existing release")
-		} else {
-			logger.Info().Msgf("Release updated: %s", rel.GetHTMLURL())
-		}
-	} else {
-		logger.Info().Msgf("Creating new release.")
-		newRelease := &github.RepositoryRelease{}
-		newRelease.TagName = &tag
-		newRelease.Name = &releaseTitle
-		newRelease.Body = &changelogContent
-		if markLatest {
-			newRelease.MakeLatest = &makeLatestTrue
-		} else {
-			newRelease.MakeLatest = &makeLatestFalse
-		}
-		if rel, _, err := gh.Repositories.CreateRelease(ctx, repoOwner, repoName, newRelease); err != nil {
-			logger.Fatal().Err(err).Msgf("Failed to create new release")
-		} else {
-			logger.Info().Msgf("Release created: %s", rel.GetHTMLURL())
-		}
+	newRelease := &github.RepositoryRelease{
+		TagName:    github.String(tag),
+		Name:       github.String(releaseTitle),
+		Body:       github.String(changelogContent),
+		MakeLatest: LatestString(latest),
 	}
+
+	url, err := CreateRelease(ctx, gh.Repositories, owner, repo, tag, newRelease)
+	if err != nil {
+		panic(err)
+	}
+
+	log.Info("release available", "url", url)
 }
 
-func generateReleaseTitle(ctx context.Context, version string, milestone *ghgql.Milestone) string {
-	date := milestone.ClosedAt
-	if !milestone.DueOn.IsZero() {
-		date = milestone.DueOn
-	}
-	if date.IsZero() {
-		date = time.Now()
-	}
-	return fmt.Sprintf("%s (%s)", version, date.Format("2006-01-02"))
-}
-
-func verifyTagExists(ctx context.Context, gh *github.Client, repoOwner string, repoName string, tag string) (bool, error) {
-	opts := github.ListOptions{}
-	opts.Page = 1
-	for {
-		tags, resp, err := gh.Repositories.ListTags(ctx, repoOwner, repoName, &opts)
-		if err != nil {
-			return false, err
-		}
-		for _, t := range tags {
-			if t.GetName() == tag {
-				return true, nil
-			}
-		}
-		if resp.NextPage <= opts.Page {
-			break
-		}
-		opts.Page = resp.NextPage
-	}
-	return false, nil
-}
-
-func retrieveChangelog(ctx context.Context, gh *github.Client, repoOwner string, repoName string, version string) (string, error) {
+func retrieveChangelog(ctx context.Context, gh *github.Client, owner string, repo string, version string) (string, error) {
 	loader := changelog.NewLoader(gh)
-	output, err := loader.LoadContent(ctx, repoOwner, repoName, version, &changelog.LoaderOptions{
+	output, err := loader.LoadContent(ctx, owner, repo, version, &changelog.LoaderOptions{
 		RemoveHeading: true,
 	})
 	if err != nil {


### PR DESCRIPTION
I was bothered that github-release didn't have any tests, so i refactored the github-release code to be testable.

I also got rid of zerolog from this action because slog exists now.