### PR TITLE
Remove logging

### DIFF
--- a/latest-release-branch/main.go
+++ b/latest-release-branch/main.go
@@ -63,6 +63,5 @@ func main() {
 		panic(err)
 	}
 
-	log.Info("found branch", "branch", branch)
 	fmt.Fprint(os.Stdout, branch)
 }


### PR DESCRIPTION
Not sure if that's gonna fix the issue but when running this action in:

https://github.com/grafana/grafana/actions/runs/13388904127/job/37391868173

we got:

```
Error: Unable to process file command 'output' successfully.
Error: Invalid format 'release-10.4.16'
```

it could be due to extra log.Info that turns the output into multiline output for the branch variable

See also https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-output-parameter