### PR TITLE
fix changelog searching to look at release branches

### DIFF
--- a/pkg/changelog/loader.go
+++ b/pkg/changelog/loader.go
@@ -50,7 +50,7 @@ func (l *Loader) LoadContent(ctx context.Context, repoOwner string, repoName str
 		fmt.Sprintf(".changelog-archive/CHANGELOG.%s.md", majorVersion),
 	}
 
-	versionBranch, err := versions.VersionBranch(version)
+	versionBranch, err := versions.ReleaseBranch(version)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/versions/version_branch.go
+++ b/pkg/versions/version_branch.go
@@ -16,3 +16,14 @@ func VersionBranch(version string) (string, error) {
 
 	return fmt.Sprintf("v%s.%s.x", groups[1], groups[2]), nil
 }
+
+func ReleaseBranch(version string) (string, error) {
+	version = strings.TrimPrefix(version, "v")
+	groups := SemverRegexp.FindStringSubmatch(version)
+	// The first group is the entire string, so we need 3 results
+	if len(groups) < 3 {
+		return "", errors.New("version does not match a semver regex")
+	}
+
+	return fmt.Sprintf("release-%s", version), nil
+}

--- a/pkg/versions/version_branch_test.go
+++ b/pkg/versions/version_branch_test.go
@@ -43,3 +43,39 @@ func TestVersionBranch(t *testing.T) {
 		assert.Equal(t, v.VersionBranch, res)
 	}
 }
+
+type releaseBranchCase struct {
+	Version       string
+	ReleaseBranch string
+}
+
+func TestReleaseBranch(t *testing.T) {
+	cases := []releaseBranchCase{
+		{
+			Version:       "8.2.1",
+			ReleaseBranch: "release-8.2.1",
+		},
+		{
+			Version:       "v9.4.0-preview",
+			ReleaseBranch: "release-9.4.0-preview",
+		},
+		{
+			Version:       "v11.0.0",
+			ReleaseBranch: "release-11.0.0",
+		},
+		{
+			Version:       "200.200.200",
+			ReleaseBranch: "release-200.200.200",
+		},
+		{
+			Version:       "v1.2.3-preview.patch-01",
+			ReleaseBranch: "release-1.2.3-preview.patch-01",
+		},
+	}
+
+	for _, v := range cases {
+		res, err := versions.ReleaseBranch(v.Version)
+		require.NoError(t, err)
+		assert.Equal(t, v.ReleaseBranch, res)
+	}
+}


### PR DESCRIPTION
uses release branches to search for changelogs instead of the old `next` branch model