### PR TITLE
extra logging in the backport process

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.23"
           cache: true
       - run: "go run ci/main.go --do-test --do-build --do-upload"

--- a/backport/backport_test.go
+++ b/backport/backport_test.go
@@ -186,7 +186,7 @@ func TestBackport(t *testing.T) {
 			EditFunc:          editFn,
 		}
 
-		pr, err := Backport(context.Background(), slog.New(slog.DiscardHandler), client, client, client, runner, BackportOpts{
+		pr, err := Backport(context.Background(), slog.Default(), client, client, client, runner, BackportOpts{
 			PullRequestNumber: 100,
 			SourceSHA:         "asdf1234",
 			SourceTitle:       "Example Bug Fix",
@@ -281,7 +281,7 @@ func TestBackport(t *testing.T) {
 			EditFunc:          editFn,
 		}
 
-		_, err := Backport(context.Background(), slog.New(slog.DiscardHandler), client, client, client, runner, BackportOpts{
+		_, err := Backport(context.Background(), slog.Default(), client, client, client, runner, BackportOpts{
 			PullRequestNumber: 100,
 			SourceSHA:         "asdf1234",
 			SourceTitle:       "Example Bug Fix",

--- a/backport/backport_test.go
+++ b/backport/backport_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
@@ -185,7 +186,7 @@ func TestBackport(t *testing.T) {
 			EditFunc:          editFn,
 		}
 
-		pr, err := Backport(context.Background(), client, client, client, runner, BackportOpts{
+		pr, err := Backport(context.Background(), slog.New(slog.DiscardHandler), client, client, client, runner, BackportOpts{
 			PullRequestNumber: 100,
 			SourceSHA:         "asdf1234",
 			SourceTitle:       "Example Bug Fix",
@@ -280,7 +281,7 @@ func TestBackport(t *testing.T) {
 			EditFunc:          editFn,
 		}
 
-		_, err := Backport(context.Background(), client, client, client, runner, BackportOpts{
+		_, err := Backport(context.Background(), slog.New(slog.DiscardHandler), client, client, client, runner, BackportOpts{
 			PullRequestNumber: 100,
 			SourceSHA:         "asdf1234",
 			SourceTitle:       "Example Bug Fix",

--- a/backport/exec.go
+++ b/backport/exec.go
@@ -63,8 +63,8 @@ func (r *ShellCommandRunner) Run(ctx context.Context, command string, args ...st
 
 	err := cmd.Run()
 
-	log.Debug(stdout.String(), "stream", "stdout")
-	log.Debug(stderr.String(), "stream", "stderr")
+	log.Debug(stdout.String(), "stream", "stdout", "exit_code", cmd.ProcessState.ExitCode())
+	log.Debug(stderr.String(), "stream", "stderr", "exit_code", cmd.ProcessState.ExitCode())
 
 	if err != nil {
 		fmt.Errorf("error running command '%s': %w", cmdstr, err)

--- a/backport/main.go
+++ b/backport/main.go
@@ -98,7 +98,7 @@ func main() {
 			Owner:             owner,
 			Repository:        repo,
 		}
-		pr, err := Backport(ctx, client.PullRequests, client.Issues, client.Issues, NewShellCommandRunner(log), opts)
+		pr, err := Backport(ctx, log, client.PullRequests, client.Issues, client.Issues, NewShellCommandRunner(log), opts)
 		if err != nil {
 			log.Error("backport failed", "error", err)
 			continue


### PR DESCRIPTION
In these logs: https://github.com/grafana/grafana/actions/runs/13401934248/job/37434454272

it is not running `git cherry-pick --abort` in a failed backport so I'm adding a bit of extra logging to see why