### PR TITLE
Fix newlines in comments

### DIFF
--- a/backport/comment.tmpl
+++ b/backport/comment.tmpl
@@ -22,7 +22,7 @@ If you have the [GitHub CLI](https://cli.github.com/) installed:
 
 ```bash
 git push --set-upstream origin {{ .BackportBranch }}
-PR_BODY=$(gh pr view {{ .SourcePullRequestNumber }} --json body --template 'Backport {{ .SourceSHA }} from #{{ .SourcePullRequestNumber }}{{ `{{ "\\n\\n---\\n\\n" }}` }}{{ `{{ index . "body" }}` }}')
+PR_BODY=$(gh pr view {{ .SourcePullRequestNumber }} --json body --template 'Backport {{ .SourceSHA }} from #{{ .SourcePullRequestNumber }}{{ `{{ "\n\\n---\n\n" }}` }}{{ `{{ index . "body" }}` }}')
 echo "${PR_BODY}" | gh pr create --title '{{ .BackportTitle }}' --body-file - {{ range .Labels }}--label '{{ . }}' {{ end }}--base {{ .Target }} --web
 ```
 

--- a/backport/comment.tmpl
+++ b/backport/comment.tmpl
@@ -22,7 +22,7 @@ If you have the [GitHub CLI](https://cli.github.com/) installed:
 
 ```bash
 git push --set-upstream origin {{ .BackportBranch }}
-PR_BODY=$(gh pr view {{ .SourcePullRequestNumber }} --json body --template 'Backport {{ .SourceSHA }} from #{{ .SourcePullRequestNumber }}{{ `{{ "\n\\n---\n\n" }}` }}{{ `{{ index . "body" }}` }}')
+PR_BODY=$(gh pr view {{ .SourcePullRequestNumber }} --json body --template 'Backport {{ .SourceSHA }} from #{{ .SourcePullRequestNumber }}{{ `{{ "\n\n---\n\n" }}` }}{{ `{{ index . "body" }}` }}')
 echo "${PR_BODY}" | gh pr create --title '{{ .BackportTitle }}' --body-file - {{ range .Labels }}--label '{{ . }}' {{ end }}--base {{ .Target }} --web
 ```
 

--- a/backport/testdata/comment.txt
+++ b/backport/testdata/comment.txt
@@ -22,7 +22,7 @@ If you have the [GitHub CLI](https://cli.github.com/) installed:
 
 ```bash
 git push --set-upstream origin backport-100-to-release-12.0.0
-PR_BODY=$(gh pr view 100 --json body --template 'Backport asdf1234 from #100{{ "\\n\\n---\\n\\n" }}{{ index . "body" }}')
+PR_BODY=$(gh pr view 100 --json body --template 'Backport asdf1234 from #100{{ "\n\n---\n\n" }}{{ index . "body" }}')
 echo "${PR_BODY}" | gh pr create --title '[release-12.0.0] Example Bug Fix' --body-file - --label 'backport' --label 'type/bug' --label 'type/example' --label 'add-to-changelog' --base release-12.0.0 --web
 ```
 


### PR DESCRIPTION
The current behavior produces output like:

```console
gh pr view 101684 --json body --template 'Backport beb884292e6f1828f59ca718651821c623c33155 from #101684{{ "\\n\\n---\\n\\n" }}{{ index . "body" }}'

Backport beb884292e6f1828f59ca718651821c623c33155 from #101684\n\n---\n\nAdded to links but not front matter in https://github.com/grafana/grafana/pull/95884/files
```

Removing one of the backslashes produces:

```console
gh pr view 101684 --json body --template 'Backport beb884292e6f1828f59ca718651821c623c33155 from #101684{{ "\n\n---\n\n" }}{{ index . "body" }}'

Backport beb884292e6f1828f59ca718651821c623c33155 from #101684

---

Added to links but not front matter in https://github.com/grafana/grafana/pull/95884/files
```