### PR TITLE
Make backport action accept PR as input instead of using event info

### DIFF
--- a/backport/action.yml
+++ b/backport/action.yml
@@ -34,7 +34,6 @@ runs:
         GITHUB_TOKEN: ${{inputs.token}}
         RELEASE_TAG: ${{inputs.binary_release_tag}}
         INPUT_LABELS_TO_ADD: ${{inputs.labels_to_add}}
-        PR: ${{inputs.pr}}
         DIR: ${{ inputs.path }}
         PR_LABEL: ${{ inputs.pr_label }}
         PR_NUMBER: ${{ inputs.pr_number }}
@@ -47,4 +46,4 @@ runs:
         chmod +x /tmp/backport
         cd $DIR
         # Execute action
-        /tmp/backport ${PR}
+        /tmp/backport

--- a/backport/action.yml
+++ b/backport/action.yml
@@ -13,21 +13,38 @@ inputs:
   path:
     required: false
     default: "."
+  pr_label:
+    description: If specified, the backport will only be created for this label
+    required: false
+  pr_number:
+    description: The number of the PR to backport
+    required: false
+  repo_owner:
+    description: The owner of the repository the PR is in
+    required: false
+  repo_name:
+    description: The name of the repository the PR is in
+    required: false
+
 runs:
   using: composite
   steps:
-  - shell: bash
-    env:
-      GITHUB_TOKEN: ${{inputs.token}}
-      RELEASE_TAG: ${{inputs.binary_release_tag}}
-      INPUT_LABELS_TO_ADD: ${{inputs.labels_to_add}}
-      PR: ${{inputs.pr}}
-      DIR: ${{ inputs.path }}
-    run: |
-      set -e
-      # Download the action from the store
-      curl --fail -L -o /tmp/backport https://github.com/grafana/grafana-github-actions-go/releases/download/${RELEASE_TAG}/backport
-      chmod +x /tmp/backport
-      cd $DIR
-      # Execute action
-      /tmp/backport ${PR}
+    - shell: bash
+      env:
+        GITHUB_TOKEN: ${{inputs.token}}
+        RELEASE_TAG: ${{inputs.binary_release_tag}}
+        INPUT_LABELS_TO_ADD: ${{inputs.labels_to_add}}
+        PR: ${{inputs.pr}}
+        DIR: ${{ inputs.path }}
+        PR_LABEL: ${{ inputs.pr_label }}
+        PR_NUMBER: ${{ inputs.pr_number }}
+        REPO_OWNER: ${{ inputs.repo_owner }}
+        REPO_NAME: ${{ inputs.repo_name }}
+      run: |
+        set -e
+        # Download the action from the store
+        curl --fail -L -o /tmp/backport https://github.com/grafana/grafana-github-actions-go/releases/download/${RELEASE_TAG}/backport
+        chmod +x /tmp/backport
+        cd $DIR
+        # Execute action
+        /tmp/backport ${PR}

--- a/backport/backport.go
+++ b/backport/backport.go
@@ -164,9 +164,7 @@ func backport(ctx context.Context, log *slog.Logger, client BackportClient, issu
 func Backport(ctx context.Context, log *slog.Logger, backportClient BackportClient, commentClient CommentClient, issueClient IssueClient, execClient CommandRunner, opts BackportOpts) (*github.PullRequest, error) {
 	// Remove any `backport` related labels from the original PR, and mark this PR as a "backport"
 	labels := []*github.Label{
-		&github.Label{
-			Name: github.String("backport"),
-		},
+		{Name: github.String("backport")},
 	}
 
 	for _, v := range opts.Labels {

--- a/backport/backport.go
+++ b/backport/backport.go
@@ -4,15 +4,12 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"regexp"
 	"strings"
 	"time"
 
 	"github.com/google/go-github/v50/github"
 	"github.com/grafana/grafana-github-actions-go/pkg/ghutil"
 )
-
-var semverRegex = regexp.MustCompile(`^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>x|0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
 
 type BackportOpts struct {
 	// PullRequestNumber is the integer ID of the pull request being backported

--- a/backport/backport_test.go
+++ b/backport/backport_test.go
@@ -78,14 +78,14 @@ func TestMostRecentBranch(t *testing.T) {
 }
 
 func TestBackportTarget(t *testing.T) {
-	assertError := func(t *testing.T, label *github.Label, branches []*github.Branch) {
+	assertError := func(t *testing.T, label string, branches []*github.Branch) {
 		t.Helper()
 		b, err := BackportTarget(label, branches)
 		assert.Error(t, err)
 		assert.Empty(t, b)
 	}
 
-	assertBranch := func(t *testing.T, label *github.Label, branches []*github.Branch, branch string) {
+	assertBranch := func(t *testing.T, label string, branches []*github.Branch, branch string) {
 		t.Helper()
 		b, err := BackportTarget(label, branches)
 		assert.NoError(t, err)
@@ -107,36 +107,16 @@ func TestBackportTarget(t *testing.T) {
 		{Name: github.String("release-12.2.12")},
 	}
 
-	assertError(t, &github.Label{
-		Name: github.String("backport v3.2.x"),
-	}, branches)
-	assertError(t, &github.Label{
-		Name: github.String("backport v4.0.x"),
-	}, branches)
-	assertError(t, &github.Label{
-		Name: github.String("backport v13.0.x"),
-	}, branches)
-	assertError(t, &github.Label{
-		Name: github.String("backport v10.5.x"),
-	}, branches)
-	assertError(t, &github.Label{
-		Name: github.String("backport v11.8.x"),
-	}, branches)
-	assertBranch(t, &github.Label{
-		Name: github.String("backport v11.0.x"),
-	}, branches, "release-11.0.1")
-	assertBranch(t, &github.Label{
-		Name: github.String("backport v12.1.x"),
-	}, branches, "release-12.1.15")
-	assertBranch(t, &github.Label{
-		Name: github.String("backport v12.0.x"),
-	}, branches, "release-12.0.15")
-	assertBranch(t, &github.Label{
-		Name: github.String("backport v1.2.x"),
-	}, branches, "release-1.2.3")
-	assertBranch(t, &github.Label{
-		Name: github.String("backport v10.2.x"),
-	}, branches, "release-10.2.4")
+	assertError(t, "backport v3.2.x", branches)
+	assertError(t, "backport v4.0.x", branches)
+	assertError(t, "backport v13.0.x", branches)
+	assertError(t, "backport v10.5.x", branches)
+	assertError(t, "backport v11.8.x", branches)
+	assertBranch(t, "backport v11.0.x", branches, "release-11.0.1")
+	assertBranch(t, "backport v12.1.x", branches, "release-12.1.15")
+	assertBranch(t, "backport v12.0.x", branches, "release-12.0.15")
+	assertBranch(t, "backport v1.2.x", branches, "release-1.2.3")
+	assertBranch(t, "backport v10.2.x", branches, "release-10.2.4")
 }
 
 type TestBackportClient struct {

--- a/backport/main.go
+++ b/backport/main.go
@@ -47,35 +47,30 @@ func main() {
 	}
 
 	var (
-		ctx     = context.Background()
-		token   = os.Getenv("GITHUB_TOKEN")
-		client  = github.NewTokenClient(ctx, token)
-		inputs  = GetInputs()
-		payload = &github.PullRequestTargetEvent{}
+		ctx    = context.Background()
+		token  = os.Getenv("GITHUB_TOKEN")
+		client = github.NewTokenClient(ctx, token)
+		inputs = GetInputs()
 	)
 
 	if token == "" {
 		panic("token can not be empty")
 	}
 
-	if err := UnmarshalEventData(ghctx, &payload); err != nil {
-		log.Error("error reading github payload", "error", err)
+	prInfo, err := GetBackportPrInfo(ctx, client, ghctx)
+	if err != nil {
+		log.Error("error getting PR info", "error", err)
 		panic(err)
 	}
 
-	var (
-		owner = payload.GetRepo().GetOwner().GetLogin()
-		repo  = payload.GetRepo().GetName()
-	)
-
-	log = log.With("pull_request", payload.GetNumber())
-	branches, err := ghutil.GetReleaseBranches(ctx, client.Repositories, owner, repo)
+	log = log.With("pull_request", prInfo.Pr.Number)
+	branches, err := ghutil.GetReleaseBranches(ctx, client.Repositories, prInfo.RepoOwner, prInfo.RepoName)
 	if err != nil {
 		log.Error("error getting branches", "error", err)
 		panic(err)
 	}
 
-	targets, err := BackportTargetsFromPayload(branches, payload)
+	targets, err := BackportTargetsFromPayload(branches, prInfo)
 	if err != nil {
 		if errors.Is(err, ErrorNotMerged) {
 			log.Warn("pull request is not merged; nothing to do")
@@ -88,28 +83,30 @@ func main() {
 
 	for _, target := range targets {
 		log := log.With("target", target)
-		mergeBase, err := MergeBase(ctx, client.Repositories, owner, repo, target.Name, *payload.GetPullRequest().Base.Ref)
+		mergeBase, err := MergeBase(ctx, client.Repositories, prInfo.RepoOwner, prInfo.RepoName, target.Name, prInfo.Pr.GetBase().GetRef())
 		if err != nil {
 			log.Error("error finding merge-base", "error", err)
 		}
 
 		opts := BackportOpts{
-			PullRequestNumber: payload.GetPullRequest().GetNumber(),
-			SourceSHA:         payload.GetPullRequest().GetMergeCommitSHA(),
-			SourceCommitDate:  payload.GetPullRequest().MergedAt.Time,
-			SourceTitle:       payload.GetPullRequest().GetTitle(),
-			SourceBody:        payload.GetPullRequest().GetBody(),
+			PullRequestNumber: prInfo.Pr.GetNumber(),
+			SourceSHA:         prInfo.Pr.GetMergeCommitSHA(),
+			SourceCommitDate:  prInfo.Pr.GetMergedAt().Time,
+			SourceTitle:       prInfo.Pr.GetTitle(),
+			SourceBody:        prInfo.Pr.GetBody(),
 			Target:            target,
-			Labels:            append(inputs.Labels, payload.GetPullRequest().Labels...),
-			Owner:             owner,
-			Repository:        repo,
+			Labels:            append(inputs.Labels, prInfo.Pr.Labels...),
+			Owner:             prInfo.RepoOwner,
+			Repository:        prInfo.RepoName,
 			MergeBase:         mergeBase,
 		}
-		pr, err := Backport(ctx, log, client.PullRequests, client.Issues, client.Issues, NewShellCommandRunner(log), opts)
+
+		prOut, err := Backport(ctx, log, client.PullRequests, client.Issues, client.Issues, NewShellCommandRunner(log), opts)
 		if err != nil {
 			log.Error("backport failed", "error", err)
 			continue
 		}
-		log.Info("backport successful", "url", pr.GetURL())
+
+		log.Info("backport successful", "url", prOut.GetURL())
 	}
 }

--- a/backport/main.go
+++ b/backport/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/google/go-github/v50/github"
@@ -52,13 +53,19 @@ func main() {
 		token  = os.Getenv("GITHUB_TOKEN")
 		client = github.NewTokenClient(ctx, token)
 		inputs = GetInputs()
+
+		// If specified, takes precedence over event data
+		repoOwner   = os.Getenv("REPO_OWNER")
+		repoName    = os.Getenv("REPO_NAME")
+		prNumber, _ = strconv.Atoi(os.Getenv("PR_NUMBER"))
+		prLabel     = os.Getenv("PR_LABEL")
 	)
 
 	if token == "" {
 		panic("token can not be empty")
 	}
 
-	prInfo, err := GetBackportPrInfo(ctx, log, client, ghctx)
+	prInfo, err := GetBackportPrInfo(ctx, log, client, ghctx, repoOwner, repoName, prNumber, prLabel)
 	if err != nil {
 		log.Error("error getting PR info", "error", err)
 		panic(err)

--- a/backport/pr_info.go
+++ b/backport/pr_info.go
@@ -36,13 +36,13 @@ func GetBackportPrInfo(ctx context.Context, client *github.Client, ghctx *github
 	// Try to use event data if present
 	eventPath := ghctx.EventPath
 	if eventPath != "" {
-		return getFromEvent(ctx, client, ghctx)
+		return getFromEvent(ghctx)
 	}
 
 	return PrInfo{}, fmt.Errorf("no PR info found")
 }
 
-func getFromEvent(ctx context.Context, client *github.Client, ghctx *githubactions.GitHubContext) (PrInfo, error) {
+func getFromEvent(ghctx *githubactions.GitHubContext) (PrInfo, error) {
 	payload := &github.PullRequestTargetEvent{}
 
 	if err := UnmarshalEventData(ghctx, &payload); err != nil {

--- a/backport/pr_info.go
+++ b/backport/pr_info.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/google/go-github/v50/github"
+	"github.com/sethvargo/go-githubactions"
+)
+
+type PrInfo struct {
+	Pr *github.PullRequest
+
+	// Contains the relevant labels for the backport.
+	// When triggered by being labeled, it should be only the applied label.
+	// When triggered by being closed, it should be all labels on the PR.
+	Labels []string
+
+	RepoOwner string
+	RepoName  string
+}
+
+func GetBackportPrInfo(ctx context.Context, client *github.Client, ghctx *githubactions.GitHubContext) (PrInfo, error) {
+	prLabel := os.Getenv("PR_LABEL")
+	prNumber, _ := strconv.Atoi(os.Getenv("PR_NUMBER"))
+	repoOwner := os.Getenv("REPO_OWNER")
+	repoName := os.Getenv("REPO_NAME")
+
+	// First, try to use the API to get the PR info
+	if prNumber != 0 && repoOwner != "" && repoName != "" {
+		return getFromApi(ctx, client, prLabel, repoOwner, repoName, prNumber)
+	}
+
+	// Try to use event data if present
+	eventPath := ghctx.EventPath
+	if eventPath != "" {
+		return getFromEvent(ctx, client, ghctx)
+	}
+
+	return PrInfo{}, fmt.Errorf("no PR info found")
+}
+
+func getFromEvent(ctx context.Context, client *github.Client, ghctx *githubactions.GitHubContext) (PrInfo, error) {
+	payload := &github.PullRequestTargetEvent{}
+
+	if err := UnmarshalEventData(ghctx, &payload); err != nil {
+		return PrInfo{}, err
+	}
+
+	if payload.PullRequest == nil {
+		return PrInfo{}, fmt.Errorf("pull request is nil")
+	}
+
+	pr := payload.GetPullRequest()
+	prInfo := PrInfo{
+		Pr:        pr,
+		RepoOwner: payload.GetRepo().GetOwner().GetLogin(),
+		RepoName:  payload.GetRepo().GetName(),
+	}
+
+	switch action := payload.GetAction(); action {
+	case "labeled":
+		prInfo.Labels = []string{payload.GetLabel().GetName()}
+	case "closed":
+		prInfo.Labels = labelsToStrings(pr.Labels)
+	default:
+		return PrInfo{}, fmt.Errorf("unsupported action: %s", action)
+	}
+
+	return prInfo, nil
+}
+
+func getFromApi(ctx context.Context, client *github.Client, prLabel, repoOwner, repoName string, prNumber int) (PrInfo, error) {
+	pr, _, err := client.PullRequests.Get(ctx, repoOwner, repoName, prNumber)
+	if err != nil {
+		return PrInfo{}, err
+	}
+
+	prInfo := PrInfo{
+		Pr:        pr,
+		RepoOwner: repoOwner,
+		RepoName:  repoName,
+	}
+
+	if prLabel != "" {
+		prInfo.Labels = []string{prLabel}
+	} else {
+		prInfo.Labels = labelsToStrings(pr.Labels)
+	}
+
+	return prInfo, nil
+}
+
+func labelsToStrings(labels []*github.Label) []string {
+	strings := make([]string, len(labels))
+	for i, label := range labels {
+		strings[i] = label.GetName()
+	}
+	return strings
+}

--- a/backport/pr_info.go
+++ b/backport/pr_info.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
-	"strconv"
 
 	"github.com/google/go-github/v50/github"
 	"github.com/sethvargo/go-githubactions"
@@ -23,21 +21,16 @@ type PrInfo struct {
 	RepoName  string
 }
 
-func GetBackportPrInfo(ctx context.Context, log *slog.Logger, client *github.Client, ghctx *githubactions.GitHubContext) (PrInfo, error) {
-	prLabel := os.Getenv("PR_LABEL")
-	prNumber, _ := strconv.Atoi(os.Getenv("PR_NUMBER"))
-	repoOwner := os.Getenv("REPO_OWNER")
-	repoName := os.Getenv("REPO_NAME")
-
+func GetBackportPrInfo(ctx context.Context, log *slog.Logger, client *github.Client, ghctx *githubactions.GitHubContext, repoOwner string, repoName string, prNumber int, prLabel string) (PrInfo, error) {
 	log.Debug("getting PR info", "event_path", ghctx.EventPath, "env_pr_label", prLabel, "env_pr_number", prNumber, "env_repo_owner", repoOwner, "env_repo_name", repoName)
 
-	// First, try to use the API to get the PR info
+	// Prefer using the env vars and API if they are set
 	if prNumber != 0 && repoOwner != "" && repoName != "" {
 		log.Debug("getting PR info from API")
 		return getFromApi(ctx, client, prLabel, repoOwner, repoName, prNumber)
 	}
 
-	// Try to use event data if present
+	// Fall back to event data if present
 	if ghctx.EventPath != "" {
 		log.Debug("getting PR info from event")
 		return getFromEvent(ghctx)

--- a/backport/release_branches_test.go
+++ b/backport/release_branches_test.go
@@ -25,16 +25,10 @@ func TestBackportTargets(t *testing.T) {
 	}
 
 	t.Run("with backport labels", func(t *testing.T) {
-		labels := []*github.Label{
-			{
-				Name: github.String("backport v12.2.x"),
-			},
-			{
-				Name: github.String("backport v12.0.x"),
-			},
-			{
-				Name: github.String("backport v11.0.x"),
-			},
+		labels := []string{
+			"backport v12.2.x",
+			"backport v12.0.x",
+			"backport v11.0.x",
 		}
 
 		targets, err := BackportTargets(branches, labels)
@@ -47,28 +41,14 @@ func TestBackportTargets(t *testing.T) {
 	})
 
 	t.Run("with non-backport labels", func(t *testing.T) {
-		labels := []*github.Label{
-			{
-				Name: github.String("type/bug"),
-			},
-			{
-				Name: github.String("backport v12.2.x"),
-			},
-			{
-				Name: github.String("release/latest"),
-			},
-			{
-				Name: github.String("backport v12.0.x"),
-			},
-			{
-				Name: github.String("type/ci"),
-			},
-			{
-				Name: github.String("backport v11.0.x"),
-			},
-			{
-				Name: github.String("add-to-changelog"),
-			},
+		labels := []string{
+			"type/bug",
+			"backport v12.2.x",
+			"release/latest",
+			"backport v12.0.x",
+			"type/ci",
+			"backport v11.0.x",
+			"add-to-changelog",
 		}
 
 		targets, err := BackportTargets(branches, labels)

--- a/latest-release-branch/main.go
+++ b/latest-release-branch/main.go
@@ -51,7 +51,7 @@ func main() {
 	}
 	major, minor, _ := ghutil.MajorMinorPatch(strings.TrimPrefix(strings.ReplaceAll(inputs.Pattern, "x", "0"), "v"))
 
-	branches, err := ghutil.GetReleaseBranches(ctx, client.Repositories, inputs.Owner, inputs.Repo)
+	branches, err := ghutil.GetReleaseBranches(ctx, log, client.Repositories, inputs.Owner, inputs.Repo)
 	if err != nil {
 		log.Error("error getting release branches", "err", err)
 		panic(err)

--- a/pkg/ghutil/release_branches.go
+++ b/pkg/ghutil/release_branches.go
@@ -3,6 +3,7 @@ package ghutil
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"slices"
 	"strconv"
 	"strings"
@@ -92,7 +93,7 @@ func MajorMinorPatch(v string) (string, string, string) {
 	return groups["major"], groups["minor"], groups["patch"]
 }
 
-func GetReleaseBranches(ctx context.Context, client BranchClient, owner, repo string) ([]*github.Branch, error) {
+func GetReleaseBranches(ctx context.Context, log *slog.Logger, client BranchClient, owner, repo string) ([]*github.Branch, error) {
 	var (
 		page     int
 		count    = 50
@@ -100,6 +101,7 @@ func GetReleaseBranches(ctx context.Context, client BranchClient, owner, repo st
 	)
 
 	for {
+		log.Debug("listing branches", "page", page, "count", count)
 		b, r, err := client.ListBranches(ctx, owner, repo, &github.BranchListOptions{
 			Protected: github.Bool(true),
 			ListOptions: github.ListOptions{


### PR DESCRIPTION
Other part to https://github.com/grafana/grafana/pull/105821

Modifies the backport action to accept inputs telling it which PR to backport, instead of relying on the event data. This allows it to work from workflow_run which doesn't have the original pull_request event.