### PR TITLE
fix: Properly match version format

### DIFF
--- a/auto-milestone/main.go
+++ b/auto-milestone/main.go
@@ -228,7 +228,7 @@ type packageJSON struct {
 	Version string `json:"version"`
 }
 
-var versionPattern = regexp.MustCompile(`^(\d+)\.(\d+).(\d+)`)
+var versionPattern = regexp.MustCompile(`^(\d+)\.(\d+)\.(\d+)`)
 
 func versionFromPackage(content string) (string, error) {
 	pjson := packageJSON{}


### PR DESCRIPTION
I was looking through this code and noticed that the second . is not properly escaped in the regex.

This doesn't really impact anything, but probably still good to fix.