### PR TITLE
backport: fix target resolution for 2-component release branches

### DIFF
--- a/backport/release_branches.go
+++ b/backport/release_branches.go
@@ -47,11 +47,12 @@ func BackportTargetsFromPayload(branches []*github.Branch, prInfo PrInfo) ([]ghu
 }
 
 // BackportTarget finds the most appropriate base branch (target) given the backport label 'label'
-// This function takes the label, like `backport v11.2.x`, and finds the most recent `release-` branch
-// that matches the pattern.
+// This function accepts both the short form `backport v11.2.x` and the release-branch
+// form `backport release-v2.8`, and finds the most recent `release-` branch that matches.
 func BackportTarget(label string, branches []*github.Branch) (ghutil.Branch, error) {
-	version := strings.TrimPrefix(label, "backport")
-	labelString := strings.ReplaceAll(strings.TrimSpace(version), "x", "0")
+	version := strings.TrimSpace(strings.TrimPrefix(label, "backport"))
+	version = strings.TrimPrefix(version, "release-")
+	labelString := strings.ReplaceAll(version, "x", "0")
 	major, minor, _ := ghutil.MajorMinorPatch(labelString)
 
 	return ghutil.MostRecentBranch(major, minor, branches)

--- a/backport/tempo_repro_test.go
+++ b/backport/tempo_repro_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-github/v50/github"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression coverage for BackportTarget across label + branch naming conventions.
+// Context: grafana/tempo#7055 — three "backport release-vX.Y" labels all
+// collapsed to the last release branch because MajorMinorPatch could not parse
+// 2-component versions or labels carrying a "release-" prefix.
+func TestBackportTarget_Formats(t *testing.T) {
+	tempoBranches := []string{
+		"release-v2.8", "release-v2.9", "release-v2.10",
+	}
+	grafanaBranches := []string{
+		"release-v11.0.0", "release-v11.2.0", "release-v11.2.1",
+		"release-8.2.0", "release-8.2.1", "release-8.2.2",
+	}
+
+	cases := []struct {
+		name     string
+		branches []string
+		label    string
+		want     string
+	}{
+		// Tempo: "release-"-prefixed label against 2-component branches.
+		{"tempo release-v2.8", tempoBranches, "backport release-v2.8", "release-v2.8"},
+		{"tempo release-v2.9", tempoBranches, "backport release-v2.9", "release-v2.9"},
+		{"tempo release-v2.10", tempoBranches, "backport release-v2.10", "release-v2.10"},
+
+		// Grafana: short-form label against 3-component branches picks newest patch.
+		{"grafana v11.2.x", grafanaBranches, "backport v11.2.x", "release-v11.2.1"},
+
+		// Grafana: 3-component branches without the "v" prefix also resolve.
+		{"grafana v8.2.x (no-v branch)", grafanaBranches, "backport v8.2.x", "release-8.2.2"},
+		{"grafana 8.2.x (no-v branch)", grafanaBranches, "backport 8.2.x", "release-8.2.2"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			br := make([]*github.Branch, len(tc.branches))
+			for i, n := range tc.branches {
+				br[i] = &github.Branch{Name: github.String(n)}
+			}
+			target, err := BackportTarget(tc.label, br)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, target.Name)
+		})
+	}
+}

--- a/pkg/versions/regex.go
+++ b/pkg/versions/regex.go
@@ -2,6 +2,6 @@ package versions
 
 import "regexp"
 
-const semverRegex = `^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`
+const semverRegex = `^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)(?:\.(?P<patch>0|[1-9]\d*))?(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`
 
 var SemverRegexp = regexp.MustCompile(semverRegex)


### PR DESCRIPTION
MajorMinorPatch used a strict 3-component semver regex, so 2-component versions (like release-v2.8) and "release-"-prefixed labels (like "backport release-v2.8") both parsed to empty strings. The filter in MostRecentBranch then matched every branch and returned the last one in the slice, causing all backport labels to collapse onto the same target. Seen on grafana/tempo#7055, where three labels (v2.8/v2.9/v2.10) all pointed at release-v2.10.

Make the patch component optional in the regex and strip "release-" from labels in BackportTarget. Existing 3-component Grafana labels and branches still resolve identically.