### PR TITLE
Migrate Release Guild ownership to GBS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @grafana/grafana-release-guild
+* @grafana/grafana-backend-services-squad

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,5 +10,5 @@ metadata:
 spec:
   type: library
   lifecycle: production
-  owner: "group:grafana-release-guild"
+  owner: "group:grafana-backend-services-squad"
   system: grafana


### PR DESCRIPTION
## Summary

Release Guild was merged into Grafana Backend Services Squad (GBS) at the org level. This PR transfers the remaining ownership references in this repo to `@grafana/grafana-backend-services-squad`.

## Changes

- `.github/CODEOWNERS` — replace `* @grafana/grafana-release-guild` with `* @grafana/grafana-backend-services-squad`
- `catalog-info.yaml` — `owner: "group:grafana-release-guild"` → `"group:grafana-backend-services-squad"`

## Context

Part of a larger migration across the release pipeline repo set. PR 1 (`grafana/grafana` #123494) and PR 2 (`grafana-enterprise` #11811) already merged. PR 3 (`deployment_tools` #570549) is in review.

## Test plan

- [x] CODEOWNERS file parses (verified by GitHub on PR view)
- [ ] After merge: confirm CODEOWNERS routes to GBS members on a follow-up PR