### PR TITLE
feat(backport): add branch_strategy param for use in mimir repo

### DIFF
--- a/backport/backport_test.go
+++ b/backport/backport_test.go
@@ -77,48 +77,6 @@ func TestMostRecentBranch(t *testing.T) {
 	assertBranch(t, "10", "2", branches, "release-10.2.4")
 }
 
-func TestBackportTarget(t *testing.T) {
-	assertError := func(t *testing.T, label string, branches []*github.Branch) {
-		t.Helper()
-		b, err := BackportTarget(label, branches)
-		assert.Error(t, err)
-		assert.Empty(t, b)
-	}
-
-	assertBranch := func(t *testing.T, label string, branches []*github.Branch, branch string) {
-		t.Helper()
-		b, err := BackportTarget(label, branches)
-		assert.NoError(t, err)
-		assert.Equal(t, branch, b.Name)
-	}
-
-	branches := []*github.Branch{
-		{Name: github.String("release-11.0.1")},
-		{Name: github.String("release-1.2.3")},
-		{Name: github.String("release-11.0.1+security-01")},
-		{Name: github.String("release-10.0.0")},
-		{Name: github.String("release-10.2.3")},
-		{Name: github.String("release-10.2.4")},
-		{Name: github.String("release-10.2.4+security-01")},
-		{Name: github.String("release-12.0.3")},
-		{Name: github.String("release-12.1.3")},
-		{Name: github.String("release-12.0.15")},
-		{Name: github.String("release-12.1.15")},
-		{Name: github.String("release-12.2.12")},
-	}
-
-	assertError(t, "backport v3.2.x", branches)
-	assertError(t, "backport v4.0.x", branches)
-	assertError(t, "backport v13.0.x", branches)
-	assertError(t, "backport v10.5.x", branches)
-	assertError(t, "backport v11.8.x", branches)
-	assertBranch(t, "backport v11.0.x", branches, "release-11.0.1")
-	assertBranch(t, "backport v12.1.x", branches, "release-12.1.15")
-	assertBranch(t, "backport v12.0.x", branches, "release-12.0.15")
-	assertBranch(t, "backport v1.2.x", branches, "release-1.2.3")
-	assertBranch(t, "backport v10.2.x", branches, "release-10.2.4")
-}
-
 type TestBackportClient struct {
 	CreateFunc        func(ctx context.Context, owner string, repo string, pull *github.NewPullRequest) (*github.PullRequest, *github.Response, error)
 	CreateCommentFunc func(ctx context.Context, owner, repo string, number int, comment *github.IssueComment) (*github.IssueComment, *github.Response, error)

--- a/backport/backport_test.go
+++ b/backport/backport_test.go
@@ -234,7 +234,7 @@ func TestBackport(t *testing.T) {
 		require.Equal(t, []string{
 			"git fetch origin asdf1234",
 			"git fetch origin release-12.0.0:refs/remotes/origin/release-12.0.0",
-			"git fetch --shallow-since=2020-01-02",
+			"git fetch --shallow-since=1577923200",
 			"git checkout -b backport-100-to-release-12.0.0 origin/release-12.0.0",
 			"git cherry-pick -x asdf1234",
 			"git push origin backport-100-to-release-12.0.0",

--- a/backport/cherrypick.go
+++ b/backport/cherrypick.go
@@ -39,7 +39,7 @@ func CreateCherryPickBranch(ctx context.Context, runner CommandRunner, branch st
 	}
 
 	// 3 Ensure that we have enough context in the local history to cherry-pick
-	if _, err := runner.Run(ctx, "git", "fetch", fmt.Sprintf("--shallow-since=%s", opts.MergeBase.Committer.Date.Format("2006-01-02"))); err != nil {
+	if _, err := runner.Run(ctx, "git", "fetch", fmt.Sprintf("--shallow-since=%d", opts.MergeBase.Committer.Date.Unix())); err != nil {
 		return fmt.Errorf("error fetching source commit: %w", err)
 	}
 

--- a/backport/cherrypick_test.go
+++ b/backport/cherrypick_test.go
@@ -40,7 +40,7 @@ func TestCreateCherryPickBranch(t *testing.T) {
 		expect := []string{
 			"git fetch origin asdf1234",
 			"git fetch origin release-1.0.0:refs/remotes/origin/release-1.0.0",
-			"git fetch --shallow-since=2020-01-02",
+			"git fetch --shallow-since=1577923200",
 			"git checkout -b example origin/release-1.0.0",
 			"git cherry-pick -x asdf1234",
 			"git diff -s --exit-code .betterer.results",
@@ -81,7 +81,7 @@ func TestCreateCherryPickBranch(t *testing.T) {
 		expect := []string{
 			"git fetch origin asdf1234",
 			"git fetch origin release-1.0.0:refs/remotes/origin/release-1.0.0",
-			"git fetch --shallow-since=2020-01-02",
+			"git fetch --shallow-since=1577923200",
 			"git checkout -b example origin/release-1.0.0",
 			"git cherry-pick -x asdf1234",
 			"git diff -s --exit-code .betterer.results",

--- a/backport/main.go
+++ b/backport/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -10,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/google/go-github/v50/github"
-	"github.com/grafana/grafana-github-actions-go/pkg/ghutil"
 	"github.com/sethvargo/go-githubactions"
 )
 
@@ -71,22 +69,19 @@ func main() {
 		panic(err)
 	}
 
-	log = log.With("repo", fmt.Sprintf("%s/%s", prInfo.RepoOwner, prInfo.RepoName), "pull_request", prInfo.Pr.GetNumber())
-
-	branches, err := ghutil.GetReleaseBranches(ctx, log, client.Repositories, prInfo.RepoOwner, prInfo.RepoName)
-	if err != nil {
-		log.Error("error getting branches", "error", err)
-		panic(err)
+	if !prInfo.Pr.GetMerged() {
+		panic("PR hasn't been merged yet")
 	}
 
-	targets, err := BackportTargetsFromPayload(branches, prInfo)
-	if err != nil {
-		if errors.Is(err, ErrorNotMerged) {
-			log.Warn("pull request is not merged; nothing to do")
-			return
-		}
+	if len(prInfo.Labels) == 0 {
+		panic("PR has no labels")
+	}
 
-		log.Error("error getting backport targets", "error", err)
+	log = log.With("repo", fmt.Sprintf("%s/%s", prInfo.RepoOwner, prInfo.RepoName), "pull_request", prInfo.Pr.GetNumber())
+
+	targetNames := BackportTargetsFromLabels(prInfo.Labels, "backport ")
+	targets, err := BackportTargets(ctx, log, client.Repositories, prInfo.RepoOwner, prInfo.RepoName, targetNames)
+	if err != nil {
 		panic(err)
 	}
 

--- a/backport/release_branches.go
+++ b/backport/release_branches.go
@@ -2,60 +2,94 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/google/go-github/v50/github"
 	"github.com/grafana/grafana-github-actions-go/pkg/ghutil"
 )
 
-func BackportTargets(branches []*github.Branch, labels []string) ([]ghutil.Branch, error) {
-	targets := []ghutil.Branch{}
-	for _, label := range labels {
-		if !strings.HasPrefix(label, "backport ") {
-			continue
-		}
-
-		target, err := BackportTarget(label, branches)
-		if err != nil {
-			return nil, fmt.Errorf("error getting target for backport label '%s': %w", label, err)
-		}
-
-		targets = append(targets, target)
-	}
-
-	return targets, nil
-}
-
-var (
-	ErrorNotMerged = errors.New("pull request is not merged; nothing to do")
-	ErrorBadAction = errors.New("unrecognized action")
-	ErrorNoLabels  = errors.New("no labels found")
-)
-
-func BackportTargetsFromPayload(branches []*github.Branch, prInfo PrInfo) ([]ghutil.Branch, error) {
-	if !prInfo.Pr.GetMerged() {
-		return nil, ErrorNotMerged
-	}
-
-	if len(prInfo.Labels) == 0 {
-		return nil, ErrorNoLabels
-	}
-
-	return BackportTargets(branches, prInfo.Labels)
-}
-
-// BackportTarget finds the most appropriate base branch (target) given the backport label 'label'
-// This function accepts both the short form `backport v11.2.x` and the release-branch
-// form `backport release-v2.8`, and finds the most recent `release-` branch that matches.
-func BackportTarget(label string, branches []*github.Branch) (ghutil.Branch, error) {
-	version := strings.TrimSpace(strings.TrimPrefix(label, "backport"))
+// BackportTarget finds the most appropriate base branch (target) given a target name.
+//
+// For example: "v12.1.x" will return "release-12.1.15", assuming a branch
+// named "release-12.1.15" is found among the candidates and its the most
+// recent one.
+func BackportTarget(version string, candidates []*github.Branch) (ghutil.Branch, error) {
 	version = strings.TrimPrefix(version, "release-")
 	labelString := strings.ReplaceAll(version, "x", "0")
 	major, minor, _ := ghutil.MajorMinorPatch(labelString)
 
-	return ghutil.MostRecentBranch(major, minor, branches)
+	return ghutil.MostRecentBranch(major, minor, candidates)
+}
+
+// BackportTargetsFromLabels extracts the list of target names from the list of
+// labels of a PR. Typically, the prefix will be "backport ".
+//
+// For example ["backport v1", "backport r123"] will return ["v1", "r123"].
+func BackportTargetsFromLabels(labels []string, prefix string) []string {
+	var targets []string
+	for _, label := range labels {
+		if !strings.HasPrefix(label, prefix) {
+			continue
+		}
+
+		n := strings.TrimSpace(strings.TrimPrefix(label, prefix))
+		targets = append(targets, n)
+	}
+
+	return targets
+}
+
+// BackportTargets finds the most appropriate base branch (target) for each
+// name.
+//
+// The accepted target names are:
+//   - a branch name
+//   - a short form `backport v11.2.x` and a release-branch form
+//     `release-v2.8`, that finds the most recent `release-` branch that
+//     matches.
+func BackportTargets(
+	ctx context.Context,
+	log *slog.Logger,
+	client ghutil.BranchClient,
+	owner, repo string,
+	names []string,
+) ([]ghutil.Branch, error) {
+	var (
+		branches  []ghutil.Branch
+		unmatched []string
+	)
+
+	// first pass matching target names as-is
+	for _, n := range names {
+		t, err := ghutil.GetReleaseBranchByName(ctx, client, owner, repo, n)
+		if err != nil {
+			unmatched = append(unmatched, n)
+		} else {
+			branches = append(branches, t)
+		}
+	}
+
+	if len(unmatched) == 0 {
+		return branches, nil
+	}
+
+	// second pass looking for branch matches
+	candidates, err := ghutil.GetReleaseBranches(ctx, log, client, owner, repo)
+	if err != nil {
+		return nil, fmt.Errorf("get release branches: %w", err)
+	}
+
+	for _, n := range unmatched {
+		t, err := BackportTarget(n, candidates)
+		if err != nil {
+			return nil, fmt.Errorf("can't find a target for %s: %w", n, err)
+		}
+		branches = append(branches, t)
+	}
+
+	return branches, nil
 }
 
 func MergeBase(ctx context.Context, client *github.RepositoriesService, owner, repo, base, head string) (*github.Commit, error) {

--- a/backport/release_branches_test.go
+++ b/backport/release_branches_test.go
@@ -4,11 +4,61 @@ import (
 	"testing"
 
 	"github.com/google/go-github/v50/github"
-	"github.com/grafana/grafana-github-actions-go/pkg/ghutil"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestBackportTargets(t *testing.T) {
+func TestBackportTargetsFromLabels(t *testing.T) {
+	t.Run("with backport labels", func(t *testing.T) {
+		labels := []string{
+			"backport v12.2.x",
+			"backport v12.0.x",
+			"backport v11.0.x",
+		}
+
+		targets := BackportTargetsFromLabels(labels, "backport ")
+		require.Equal(t, []string{
+			"v12.2.x",
+			"v12.0.x",
+			"v11.0.x",
+		}, targets)
+	})
+
+	t.Run("with non-backport labels", func(t *testing.T) {
+		labels := []string{
+			"type/bug",
+			"backport v12.2.x",
+			"release/latest",
+			"backport v12.0.x",
+			"type/ci",
+			"backport v11.0.x",
+			"add-to-changelog",
+		}
+
+		targets := BackportTargetsFromLabels(labels, "backport ")
+		require.Equal(t, []string{
+			"v12.2.x",
+			"v12.0.x",
+			"v11.0.x",
+		}, targets)
+	})
+}
+
+func TestBackportTarget(t *testing.T) {
+	assertError := func(t *testing.T, label string, branches []*github.Branch) {
+		t.Helper()
+		b, err := BackportTarget(label, branches)
+		assert.Error(t, err)
+		assert.Empty(t, b)
+	}
+
+	assertBranch := func(t *testing.T, label string, branches []*github.Branch, branch string) {
+		t.Helper()
+		b, err := BackportTarget(label, branches)
+		assert.NoError(t, err)
+		assert.Equal(t, branch, b.Name)
+	}
+
 	branches := []*github.Branch{
 		{Name: github.String("release-11.0.1")},
 		{Name: github.String("release-1.2.3")},
@@ -24,50 +74,14 @@ func TestBackportTargets(t *testing.T) {
 		{Name: github.String("release-12.2.12")},
 	}
 
-	t.Run("with backport labels", func(t *testing.T) {
-		labels := []string{
-			"backport v12.2.x",
-			"backport v12.0.x",
-			"backport v11.0.x",
-		}
-
-		targets, err := BackportTargets(branches, labels)
-		require.NoError(t, err)
-		require.Equal(t, []string{
-			"release-12.2.12",
-			"release-12.0.15",
-			"release-11.0.1",
-		}, toStringList(targets))
-	})
-
-	t.Run("with non-backport labels", func(t *testing.T) {
-		labels := []string{
-			"type/bug",
-			"backport v12.2.x",
-			"release/latest",
-			"backport v12.0.x",
-			"type/ci",
-			"backport v11.0.x",
-			"add-to-changelog",
-		}
-
-		targets, err := BackportTargets(branches, labels)
-		require.NoError(t, err)
-		require.Equal(t, []string{
-			"release-12.2.12",
-			"release-12.0.15",
-			"release-11.0.1",
-		}, toStringList(targets))
-	})
-
-}
-
-func toStringList(branches []ghutil.Branch) []string {
-	r := make([]string, len(branches))
-
-	for i, v := range branches {
-		r[i] = v.Name
-	}
-
-	return r
+	assertError(t, "v3.2.x", branches)
+	assertError(t, "v4.0.x", branches)
+	assertError(t, "v13.0.x", branches)
+	assertError(t, "v10.5.x", branches)
+	assertError(t, "v11.8.x", branches)
+	assertBranch(t, "v11.0.x", branches, "release-11.0.1")
+	assertBranch(t, "v12.1.x", branches, "release-12.1.15")
+	assertBranch(t, "v12.0.x", branches, "release-12.0.15")
+	assertBranch(t, "v1.2.x", branches, "release-1.2.3")
+	assertBranch(t, "v10.2.x", branches, "release-10.2.4")
 }

--- a/backport/tempo_repro_test.go
+++ b/backport/tempo_repro_test.go
@@ -27,16 +27,16 @@ func TestBackportTarget_Formats(t *testing.T) {
 		want     string
 	}{
 		// Tempo: "release-"-prefixed label against 2-component branches.
-		{"tempo release-v2.8", tempoBranches, "backport release-v2.8", "release-v2.8"},
-		{"tempo release-v2.9", tempoBranches, "backport release-v2.9", "release-v2.9"},
-		{"tempo release-v2.10", tempoBranches, "backport release-v2.10", "release-v2.10"},
+		{"tempo release-v2.8", tempoBranches, "release-v2.8", "release-v2.8"},
+		{"tempo release-v2.9", tempoBranches, "release-v2.9", "release-v2.9"},
+		{"tempo release-v2.10", tempoBranches, "release-v2.10", "release-v2.10"},
 
 		// Grafana: short-form label against 3-component branches picks newest patch.
-		{"grafana v11.2.x", grafanaBranches, "backport v11.2.x", "release-v11.2.1"},
+		{"grafana v11.2.x", grafanaBranches, "v11.2.x", "release-v11.2.1"},
 
 		// Grafana: 3-component branches without the "v" prefix also resolve.
-		{"grafana v8.2.x (no-v branch)", grafanaBranches, "backport v8.2.x", "release-8.2.2"},
-		{"grafana 8.2.x (no-v branch)", grafanaBranches, "backport 8.2.x", "release-8.2.2"},
+		{"grafana v8.2.x (no-v branch)", grafanaBranches, "v8.2.x", "release-8.2.2"},
+		{"grafana 8.2.x (no-v branch)", grafanaBranches, "8.2.x", "release-8.2.2"},
 	}
 
 	for _, tc := range cases {

--- a/latest-release-branch/main.go
+++ b/latest-release-branch/main.go
@@ -27,6 +27,7 @@ func GetInputs() Inputs {
 	r := strings.Split(ownerRepo, "/")
 	owner := r[0]
 	repo := r[1]
+
 	return Inputs{
 		Pattern: pattern,
 		Owner:   owner,

--- a/pkg/ghutil/release_branches.go
+++ b/pkg/ghutil/release_branches.go
@@ -14,6 +14,7 @@ import (
 
 type BranchClient interface {
 	ListBranches(ctx context.Context, owner string, repo string, opts *github.BranchListOptions) ([]*github.Branch, *github.Response, error)
+	GetBranch(ctx context.Context, owner, repo, branch string, followRedirects bool) (*github.Branch, *github.Response, error)
 }
 
 type Branch struct {
@@ -122,4 +123,12 @@ func GetReleaseBranches(ctx context.Context, log *slog.Logger, client BranchClie
 	}
 
 	return branches, nil
+}
+
+func GetReleaseBranchByName(ctx context.Context, client BranchClient, owner, repo string, name string) (Branch, error) {
+	b, _, err := client.GetBranch(ctx, owner, repo, name, true)
+	return Branch{
+		Name: b.GetName(),
+		SHA:  b.GetCommit().GetSHA(),
+	}, err
 }


### PR DESCRIPTION
The grafana/mimir repo uses a different conventions where release branches are named 'rXXX' (e.g. 'r123') and the label added to a PR that needs to be backported is 'backport rXXX', instead of 'release-vX.Y.Z'.

This commit makes the GitHub action look up for branches named exactly as the label target, and fallbacks to the old behaviour when there isn't one.