### PR TITLE
feat(backport): build binary from source instead of downloading from release

### DIFF
--- a/backport/action.yml
+++ b/backport/action.yml
@@ -4,9 +4,6 @@ inputs:
   token:
     description: GitHub token with access to all necessary repositories
     required: true
-  labelsToAdd:
-    description: Comma delimited list of labels to add to the backport PRs
-    required: true
   path:
     required: false
     default: "."
@@ -69,7 +66,6 @@ runs:
     - shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
-        INPUT_LABELS_TO_ADD: ${{ inputs.labels_to_add }}
         DIR: ${{ inputs.path }}
         PR_LABEL: ${{ inputs.pr_label }}
         PR_NUMBER: ${{ inputs.pr_number }}

--- a/backport/action.yml
+++ b/backport/action.yml
@@ -7,9 +7,6 @@ inputs:
   labelsToAdd:
     description: Comma delimited list of labels to add to the backport PRs
     required: true
-  binary_release_tag:
-    required: false
-    default: "dev"
   path:
     required: false
     default: "."
@@ -29,21 +26,56 @@ inputs:
 runs:
   using: composite
   steps:
+    # We build from source instead of downloading a prebuilt release binary.
+    # Pinning this action to a commit SHA only protects what runs if the SHA
+    # determines the code; release assets are mutable, so a SHA-pinned action
+    # that fetches one isn't actually pinning the binary version.
+    #
+    # The build is cached by runner OS/arch + hash of Go sources, so it only
+    # reruns when the source changes.
+
+    - id: source-hash
+      shell: bash
+      run: |
+        set -euo pipefail
+        cd "${GITHUB_ACTION_PATH}/.."
+        hash=$(find . -type f \( -name '*.go' -o -name 'go.mod' -o -name 'go.sum' \) \
+          | sort \
+          | xargs sha256sum \
+          | sha256sum \
+          | cut -d' ' -f1)
+        echo "hash=${hash}" >> "${GITHUB_OUTPUT}"
+
+    - id: cache
+      uses: actions/cache@v4
+      with:
+        path: /tmp/backport
+        key: backport-${{ runner.os }}-${{ runner.arch }}-${{ steps.source-hash.outputs.hash }}
+
+    - if: steps.cache.outputs.cache-hit != 'true'
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: ${{ github.action_path }}/../go.mod
+        cache: false
+
+    - if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        cd "${GITHUB_ACTION_PATH}/.."
+        CGO_ENABLED=0 go build -trimpath -o /tmp/backport ./backport
+        chmod +x /tmp/backport
+
     - shell: bash
       env:
-        GITHUB_TOKEN: ${{inputs.token}}
-        RELEASE_TAG: ${{inputs.binary_release_tag}}
-        INPUT_LABELS_TO_ADD: ${{inputs.labels_to_add}}
+        GITHUB_TOKEN: ${{ inputs.token }}
+        INPUT_LABELS_TO_ADD: ${{ inputs.labels_to_add }}
         DIR: ${{ inputs.path }}
         PR_LABEL: ${{ inputs.pr_label }}
         PR_NUMBER: ${{ inputs.pr_number }}
         REPO_OWNER: ${{ inputs.repo_owner }}
         REPO_NAME: ${{ inputs.repo_name }}
       run: |
-        set -e
-        # Download the action from the store
-        curl --fail -L -o /tmp/backport https://github.com/grafana/grafana-github-actions-go/releases/download/${RELEASE_TAG}/backport
-        chmod +x /tmp/backport
-        cd $DIR
-        # Execute action
+        set -euo pipefail
+        cd "${DIR}"
         /tmp/backport


### PR DESCRIPTION
## What

Build the `backport` binary from source on each action invocation (cached by source content hash) instead of downloading it from the mutable `dev` release tag.

Drive-by: remove unused param `labelsToAdd`

## Why

The `dev` release tag gets re-uploaded on every push to `main`, so a consumer pinning `grafana/grafana-github-actions-go/backport@<sha>` doesn't actually pin the binary — anyone with release write access can swap it out from under pinned consumers. Building from source ties the binary 1:1 to the commit the consumer pinned; `go.sum` covers Go module integrity.

Cache key is `sha256(*.go + go.mod + go.sum)`, so unchanged source reuses the binary across runs. `setup-go` and `go build` only run on a cache miss.

**Cold cache ≈ 30s. Warm cache ≈ 1s.**

## Breaking changes

- `labelsToAdd` → `labels_to_add`. The old name silently produced an empty `INPUT_LABELS_TO_ADD` env var because the wiring referenced `inputs.labels_to_add` against an input declared as `labelsToAdd`. Consumers passing the old name will see an "Unexpected input" annotation — same observable behavior as before, now with a warning.
- `binary_release_tag` input removed (no-op; safely ignored if still passed).

## Tests

Ran four PRs end-to-end against a throwaway repo ([pitasi/backport-action-test](https://github.com/pitasi/backport-action-test)) using `pitasi/grafana-github-actions-go/backport@harden-actions-pin-binary-hash`:

| Run | Cache | Duration | Result |
|-----|-------|----------|--------|
| 1 | miss → setup-go + `go build` ran | 30s | binary built and executed |
| 2 | hit (setup-go + build skipped) | 12s | binary executed; failed at cherry-pick (runner had no `git user.email` configured — pre-existing binary behavior, unrelated to this change) |
| 3 | hit | 24s | binary reached PR-creation API; failed because the test repo's "Allow GH Actions to create PRs" setting was off |
| 4 | hit | 17s | **backport PR created end-to-end with `labels_to_add` value applied** ([example](https://github.com/pitasi/backport-action-test/pull/5)) |

Cache key was identical across runs 2/3/4 (`backport-Linux-X64-acaa885f8f7ca07c1eff6347e82ea82a76e8e02ba6be67e330cf94e2b41cacbe`), confirming the content hash is deterministic across invocations.