### PR TITLE
Harden all actions: build binary from source via shared composite action

### DIFF
--- a/auto-milestone/action.yml
+++ b/auto-milestone/action.yml
@@ -19,25 +19,23 @@ inputs:
   metrics_api_endpoint:
     description: Full URL of a Graphite HTTP endpoint
     required: false
-  binary_release_tag:
-    required: false
-    default: "dev"
 runs:
   using: composite
   steps:
-  - run: |
-      set -e
-      # Download the action from the store
-      curl --fail -L -o /tmp/auto-milestone https://github.com/grafana/grafana-github-actions-go/releases/download/${RELEASE_TAG}/auto-milestone
-      chmod +x /tmp/auto-milestone
-      # Execute action
-      /tmp/auto-milestone ${PR}
-    shell: bash
-    env:
-      GITHUB_TOKEN: ${{inputs.token}}
-      INPUT_METRICS_API_USERNAME: ${{inputs.metrics_api_username}}
-      INPUT_METRICS_API_KEY: ${{inputs.metrics_api_key}}
-      INPUT_METRICS_API_ENDPOINT: ${{inputs.metrics_api_endpoint}}
-      INPUT_VERSION_SOURCE_REPOSITORY: ${{inputs.version_source_repository}}
-      RELEASE_TAG: ${{inputs.binary_release_tag}}
-      PR: ${{inputs.pr}}
+    - id: build
+      uses: ./build-go-binary
+      with:
+        binary_name: auto-milestone
+
+    - shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+        INPUT_METRICS_API_USERNAME: ${{ inputs.metrics_api_username }}
+        INPUT_METRICS_API_KEY: ${{ inputs.metrics_api_key }}
+        INPUT_METRICS_API_ENDPOINT: ${{ inputs.metrics_api_endpoint }}
+        INPUT_VERSION_SOURCE_REPOSITORY: ${{ inputs.version_source_repository }}
+        PR: ${{ inputs.pr }}
+        BINARY: ${{ steps.build.outputs.path }}
+      run: |
+        set -euo pipefail
+        "${BINARY}" "${PR}"

--- a/backport/action.yml
+++ b/backport/action.yml
@@ -23,45 +23,10 @@ inputs:
 runs:
   using: composite
   steps:
-    # We build from source instead of downloading a prebuilt release binary.
-    # Pinning this action to a commit SHA only protects what runs if the SHA
-    # determines the code; release assets are mutable, so a SHA-pinned action
-    # that fetches one isn't actually pinning the binary version.
-    #
-    # The build is cached by runner OS/arch + hash of Go sources, so it only
-    # reruns when the source changes.
-
-    - id: source-hash
-      shell: bash
-      run: |
-        set -euo pipefail
-        cd "${GITHUB_ACTION_PATH}/.."
-        hash=$(find . -type f \( -name '*.go' -o -name 'go.mod' -o -name 'go.sum' \) \
-          | sort \
-          | xargs sha256sum \
-          | sha256sum \
-          | cut -d' ' -f1)
-        echo "hash=${hash}" >> "${GITHUB_OUTPUT}"
-
-    - id: cache
-      uses: actions/cache@v4
+    - id: build
+      uses: ./build-go-binary
       with:
-        path: /tmp/backport
-        key: backport-${{ runner.os }}-${{ runner.arch }}-${{ steps.source-hash.outputs.hash }}
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: ${{ github.action_path }}/../go.mod
-        cache: false
-
-    - if: steps.cache.outputs.cache-hit != 'true'
-      shell: bash
-      run: |
-        set -euo pipefail
-        cd "${GITHUB_ACTION_PATH}/.."
-        CGO_ENABLED=0 go build -trimpath -o /tmp/backport ./backport
-        chmod +x /tmp/backport
+        binary_name: backport
 
     - shell: bash
       env:
@@ -71,7 +36,8 @@ runs:
         PR_NUMBER: ${{ inputs.pr_number }}
         REPO_OWNER: ${{ inputs.repo_owner }}
         REPO_NAME: ${{ inputs.repo_name }}
+        BINARY: ${{ steps.build.outputs.path }}
       run: |
         set -euo pipefail
         cd "${DIR}"
-        /tmp/backport
+        "${BINARY}"

--- a/build-go-binary/action.yml
+++ b/build-go-binary/action.yml
@@ -1,0 +1,59 @@
+name: Build Go binary
+description: |
+  Builds one of the Go binaries in this repository from source, caching the
+  result by source content hash so repeated runs reuse the binary (~1s warm,
+  ~30s cold).
+
+  We build from source instead of downloading a prebuilt release asset because
+  release assets are mutable: a consumer pinning this action to a commit SHA
+  is not actually pinning the binary unless the binary itself is determined
+  by that SHA. Building from source ties the binary 1:1 to the pinned commit.
+
+inputs:
+  binary_name:
+    description: Name of the Go package directory at the repo root to build (also used as the output binary name).
+    required: true
+
+outputs:
+  path:
+    description: Absolute path of the built binary.
+    value: /tmp/${{ inputs.binary_name }}
+
+runs:
+  using: composite
+  steps:
+    - id: source-hash
+      shell: bash
+      env:
+        BINARY_NAME: ${{ inputs.binary_name }}
+      run: |
+        set -euo pipefail
+        cd "${GITHUB_ACTION_PATH}/.."
+        hash=$(find . -type f \( -name '*.go' -o -name 'go.mod' -o -name 'go.sum' \) \
+          | sort \
+          | xargs sha256sum \
+          | sha256sum \
+          | cut -d' ' -f1)
+        echo "hash=${hash}" >> "${GITHUB_OUTPUT}"
+
+    - id: cache
+      uses: actions/cache@v4
+      with:
+        path: /tmp/${{ inputs.binary_name }}
+        key: ${{ inputs.binary_name }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.source-hash.outputs.hash }}
+
+    - if: steps.cache.outputs.cache-hit != 'true'
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: ${{ github.action_path }}/../go.mod
+        cache: false
+
+    - if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        BINARY_NAME: ${{ inputs.binary_name }}
+      run: |
+        set -euo pipefail
+        cd "${GITHUB_ACTION_PATH}/.."
+        CGO_ENABLED=0 go build -trimpath -o "/tmp/${BINARY_NAME}" "./${BINARY_NAME}"
+        chmod +x "/tmp/${BINARY_NAME}"

--- a/build-go-binary/action.yml
+++ b/build-go-binary/action.yml
@@ -28,11 +28,14 @@ runs:
       run: |
         set -euo pipefail
         cd "${GITHUB_ACTION_PATH}/.."
-        hash=$(find . -type f \( -name '*.go' -o -name 'go.mod' -o -name 'go.sum' \) \
-          | sort \
-          | xargs sha256sum \
-          | sha256sum \
-          | cut -d' ' -f1)
+        files=$(find . -type f \( -name '*.go' -o -name 'go.mod' -o -name 'go.sum' \) -print0 \
+          | sort -z \
+          | xargs -0 sha256sum)
+        if [ -z "${files}" ]; then
+          echo "source-hash: no Go source files found under $(pwd)" >&2
+          exit 1
+        fi
+        hash=$(printf '%s\n' "${files}" | sha256sum | cut -d' ' -f1)
         echo "hash=${hash}" >> "${GITHUB_OUTPUT}"
 
     - id: cache

--- a/build-go-binary/action.yml
+++ b/build-go-binary/action.yml
@@ -1,8 +1,7 @@
 name: Build Go binary
 description: |
   Builds one of the Go binaries in this repository from source, caching the
-  result by source content hash so repeated runs reuse the binary (~1s warm,
-  ~30s cold).
+  result by source content hash so repeated runs reuse the binary.
 
   We build from source instead of downloading a prebuilt release asset because
   release assets are mutable: a consumer pinning this action to a commit SHA

--- a/bump-release/action.yml
+++ b/bump-release/action.yml
@@ -31,5 +31,5 @@ runs:
         BINARY: ${{ steps.build.outputs.path }}
       run: |
         set -euo pipefail
-        "${BINARY}" > branch
-        echo "branch=$(cat branch)" >> "$GITHUB_OUTPUT"
+        branch=$("${BINARY}")
+        echo "branch=${branch}" >> "$GITHUB_OUTPUT"

--- a/bump-release/action.yml
+++ b/bump-release/action.yml
@@ -7,9 +7,6 @@ inputs:
   source:
     description: The existing release branch name. (eg `release-11.3.4`)
     required: true
-  binary_release_tag:
-    required: false
-    default: "dev"
   token:
     description: GitHub token with access to all necessary repositories
     required: true
@@ -20,18 +17,19 @@ outputs:
 runs:
   using: composite
   steps:
-  - shell: bash
-    id: bump-release
-    env:
-      GITHUB_TOKEN: ${{inputs.token}}
-      INPUT_OWNERREPO: ${{inputs.ownerRepo}}
-      INPUT_SOURCE: ${{inputs.source}}
-      RELEASE_TAG: ${{inputs.binary_release_tag}}
-    run: |
-      set -e
-      # Download the action from the store
-      curl --fail -L -o /tmp/bump-release https://github.com/grafana/grafana-github-actions-go/releases/download/${RELEASE_TAG}/bump-release
-      chmod +x /tmp/bump-release
-      # Execute action
-      /tmp/bump-release > branch
-      echo "branch=$(cat branch)" >> "$GITHUB_OUTPUT"
+    - id: build
+      uses: ./build-go-binary
+      with:
+        binary_name: bump-release
+
+    - id: bump-release
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+        INPUT_OWNERREPO: ${{ inputs.ownerRepo }}
+        INPUT_SOURCE: ${{ inputs.source }}
+        BINARY: ${{ steps.build.outputs.path }}
+      run: |
+        set -euo pipefail
+        "${BINARY}" > branch
+        echo "branch=$(cat branch)" >> "$GITHUB_OUTPUT"

--- a/community-release/action.yml
+++ b/community-release/action.yml
@@ -26,31 +26,29 @@ inputs:
   metrics_api_endpoint:
     description: Full URL of a Graphite HTTP endpoint
     required: false
-  binary_release_tag:
-    required: false
-    default: "dev"
   dry_run:
     default: false
 runs:
   using: composite
   steps:
-  - run: |
-      set -e
-      # Download the action from the store
-      curl --fail -L -o /tmp/community-release https://github.com/grafana/grafana-github-actions-go/releases/download/${RELEASE_TAG}/community-release
-      chmod +x /tmp/community-release
-      # Execute action
-      /tmp/community-release --preview=${DRY_RUN}
-    shell: bash
-    env:
-      GITHUB_TOKEN: ${{inputs.token}}
-      INPUT_VERSION: ${{inputs.version}}
-      INPUT_METRICS_API_USERNAME: ${{inputs.metrics_api_username}}
-      INPUT_METRICS_API_KEY: ${{inputs.metrics_api_key}}
-      INPUT_METRICS_API_ENDPOINT: ${{inputs.metrics_api_endpoint}}
-      INPUT_COMMUNITY_API_USERNAME: ${{inputs.community_api_username}}
-      INPUT_COMMUNITY_API_KEY: ${{inputs.community_api_key}}
-      INPUT_COMMUNITY_BASE_URL: ${{inputs.community_base_url}}
-      INPUT_COMMUNITY_CATEGORY_ID: ${{inputs.community_category_id}}
-      DRY_RUN: ${{inputs.dry_run}}
-      RELEASE_TAG: ${{inputs.binary_release_tag}}
+    - id: build
+      uses: ./build-go-binary
+      with:
+        binary_name: community-release
+
+    - shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+        INPUT_VERSION: ${{ inputs.version }}
+        INPUT_METRICS_API_USERNAME: ${{ inputs.metrics_api_username }}
+        INPUT_METRICS_API_KEY: ${{ inputs.metrics_api_key }}
+        INPUT_METRICS_API_ENDPOINT: ${{ inputs.metrics_api_endpoint }}
+        INPUT_COMMUNITY_API_USERNAME: ${{ inputs.community_api_username }}
+        INPUT_COMMUNITY_API_KEY: ${{ inputs.community_api_key }}
+        INPUT_COMMUNITY_BASE_URL: ${{ inputs.community_base_url }}
+        INPUT_COMMUNITY_CATEGORY_ID: ${{ inputs.community_category_id }}
+        DRY_RUN: ${{ inputs.dry_run }}
+        BINARY: ${{ steps.build.outputs.path }}
+      run: |
+        set -euo pipefail
+        "${BINARY}" --preview="${DRY_RUN}"

--- a/github-release/action.yml
+++ b/github-release/action.yml
@@ -16,9 +16,6 @@ inputs:
   metrics_api_endpoint:
     description: Full URL of a Graphite HTTP endpoint
     required: false
-  binary_release_tag:
-    required: false
-    default: "dev"
   latest:
     description: Mark the release as latest (1 for latest, 0 for not)
     required: false
@@ -28,20 +25,21 @@ inputs:
 runs:
   using: composite
   steps:
-  - run: |
-      set -e
-      # Download the action from the store
-      curl --fail -L -o /tmp/github-release https://github.com/grafana/grafana-github-actions-go/releases/download/${RELEASE_TAG}/github-release
-      chmod +x /tmp/github-release
-      # Execute action
-      /tmp/github-release --preview=${DRY_RUN} ${VERSION}
-    shell: bash
-    env:
-      GITHUB_TOKEN: ${{inputs.token}}
-      INPUT_METRICS_API_USERNAME: ${{inputs.metrics_api_username}}
-      INPUT_METRICS_API_KEY: ${{inputs.metrics_api_key}}
-      INPUT_METRICS_API_ENDPOINT: ${{inputs.metrics_api_endpoint}}
-      INPUT_LATEST: ${{inputs.latest}}
-      RELEASE_TAG: ${{inputs.binary_release_tag}}
-      DRY_RUN: ${{inputs.dry_run}}
-      VERSION: ${{inputs.version}}
+    - id: build
+      uses: ./build-go-binary
+      with:
+        binary_name: github-release
+
+    - shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+        INPUT_METRICS_API_USERNAME: ${{ inputs.metrics_api_username }}
+        INPUT_METRICS_API_KEY: ${{ inputs.metrics_api_key }}
+        INPUT_METRICS_API_ENDPOINT: ${{ inputs.metrics_api_endpoint }}
+        INPUT_LATEST: ${{ inputs.latest }}
+        DRY_RUN: ${{ inputs.dry_run }}
+        VERSION: ${{ inputs.version }}
+        BINARY: ${{ steps.build.outputs.path }}
+      run: |
+        set -euo pipefail
+        "${BINARY}" --preview="${DRY_RUN}" "${VERSION}"

--- a/latest-release-branch/action.yml
+++ b/latest-release-branch/action.yml
@@ -10,9 +10,6 @@ inputs:
   pattern:
     description: The pattern to use to search for a release branch (eg `v11.3.x`)
     required: true
-  binary_release_tag:
-    required: false
-    default: "dev"
 outputs:
   branch:
     description: The latest release branch that matches the pattern
@@ -20,17 +17,18 @@ outputs:
 runs:
   using: composite
   steps:
-  - shell: bash
-    id: get-latest-release-branch
-    env:
-      GITHUB_TOKEN: ${{inputs.token}}
-      INPUT_OWNERREPO: ${{inputs.ownerRepo}}
-      INPUT_PATTERN: ${{inputs.pattern}}
-      RELEASE_TAG: ${{inputs.binary_release_tag}}
-    run: |
-      set -e
-      # Download the action from the store
-      curl --fail -L -o /tmp/latest-release-branch https://github.com/grafana/grafana-github-actions-go/releases/download/${RELEASE_TAG}/latest-release-branch
-      chmod +x /tmp/latest-release-branch
-      # Execute action
-      echo "branch=$(/tmp/latest-release-branch)" >> "$GITHUB_OUTPUT" 
+    - id: build
+      uses: ./build-go-binary
+      with:
+        binary_name: latest-release-branch
+
+    - id: get-latest-release-branch
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+        INPUT_OWNERREPO: ${{ inputs.ownerRepo }}
+        INPUT_PATTERN: ${{ inputs.pattern }}
+        BINARY: ${{ steps.build.outputs.path }}
+      run: |
+        set -euo pipefail
+        echo "branch=$("${BINARY}")" >> "$GITHUB_OUTPUT"

--- a/latest-release-branch/action.yml
+++ b/latest-release-branch/action.yml
@@ -31,4 +31,5 @@ runs:
         BINARY: ${{ steps.build.outputs.path }}
       run: |
         set -euo pipefail
-        echo "branch=$("${BINARY}")" >> "$GITHUB_OUTPUT"
+        branch=$("${BINARY}")
+        echo "branch=${branch}" >> "$GITHUB_OUTPUT"

--- a/migrate-open-prs/README.md
+++ b/migrate-open-prs/README.md
@@ -49,5 +49,4 @@ jobs:
           ownerRepo: 'grafana/grafana'
           from: ${{ inputs.from }}
           to: ${{ inputs.to }}
-          binary_release_tag: 'dev'
 ```

--- a/migrate-open-prs/action.yml
+++ b/migrate-open-prs/action.yml
@@ -13,22 +13,22 @@ inputs:
   to:
     description: The base branch to migrate open PRs to
     required: true
-  binary_release_tag:
-    required: false
-    default: "dev"
 runs:
   using: composite
   steps:
-  - shell: bash
-    id: migrate-open-prs
-    env:
-      GITHUB_TOKEN: ${{inputs.token}}
-      INPUT_OWNERREPO: ${{inputs.ownerRepo}}
-      INPUT_FROM: ${{inputs.from}}
-      INPUT_TO: ${{inputs.to}}
-      RELEASE_TAG: ${{inputs.binary_release_tag}}
-    run: |
-      set -e
-      curl --fail -L -o /tmp/migrate-open-prs https://github.com/grafana/grafana-github-actions-go/releases/download/${RELEASE_TAG}/migrate-open-prs
-      chmod +x /tmp/migrate-open-prs
-      /tmp/migrate-open-prs
+    - id: build
+      uses: ./build-go-binary
+      with:
+        binary_name: migrate-open-prs
+
+    - id: migrate-open-prs
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+        INPUT_OWNERREPO: ${{ inputs.ownerRepo }}
+        INPUT_FROM: ${{ inputs.from }}
+        INPUT_TO: ${{ inputs.to }}
+        BINARY: ${{ steps.build.outputs.path }}
+      run: |
+        set -euo pipefail
+        "${BINARY}"

--- a/update-changelog/action.yml
+++ b/update-changelog/action.yml
@@ -32,30 +32,28 @@ inputs:
   skip_community_post:
     required: false
     default: "0"
-  binary_release_tag:
-    required: false
-    default: "dev"
 runs:
   using: composite
   steps:
-  - run: |
-      set -e
-      # Download the action from the store
-      curl --fail -L -o /tmp/update-changelog https://github.com/grafana/grafana-github-actions-go/releases/download/${RELEASE_TAG}/update-changelog
-      chmod +x /tmp/update-changelog
-      # Execute action
-      /tmp/update-changelog
-    shell: bash
-    env:
-      GITHUB_TOKEN: ${{inputs.token}}
-      INPUT_VERSION: ${{inputs.version}}
-      INPUT_METRICS_API_USERNAME: ${{inputs.metrics_api_username}}
-      INPUT_METRICS_API_KEY: ${{inputs.metrics_api_key}}
-      INPUT_METRICS_API_ENDPOINT: ${{inputs.metrics_api_endpoint}}
-      INPUT_COMMUNITY_API_USERNAME: ${{inputs.community_api_username}}
-      INPUT_COMMUNITY_API_KEY: ${{inputs.community_api_key}}
-      INPUT_COMMUNITY_BASE_URL: ${{inputs.community_base_url}}
-      INPUT_COMMUNITY_CATEGORY_ID: ${{inputs.community_category_id}}
-      INPUT_SKIP_PR: ${{inputs.skip_pr}}
-      INPUT_SKIP_COMMUNITY_POST: ${{inputs.skip_community_post}}
-      RELEASE_TAG: ${{inputs.binary_release_tag}}
+    - id: build
+      uses: ./build-go-binary
+      with:
+        binary_name: update-changelog
+
+    - shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+        INPUT_VERSION: ${{ inputs.version }}
+        INPUT_METRICS_API_USERNAME: ${{ inputs.metrics_api_username }}
+        INPUT_METRICS_API_KEY: ${{ inputs.metrics_api_key }}
+        INPUT_METRICS_API_ENDPOINT: ${{ inputs.metrics_api_endpoint }}
+        INPUT_COMMUNITY_API_USERNAME: ${{ inputs.community_api_username }}
+        INPUT_COMMUNITY_API_KEY: ${{ inputs.community_api_key }}
+        INPUT_COMMUNITY_BASE_URL: ${{ inputs.community_base_url }}
+        INPUT_COMMUNITY_CATEGORY_ID: ${{ inputs.community_category_id }}
+        INPUT_SKIP_PR: ${{ inputs.skip_pr }}
+        INPUT_SKIP_COMMUNITY_POST: ${{ inputs.skip_community_post }}
+        BINARY: ${{ steps.build.outputs.path }}
+      run: |
+        set -euo pipefail
+        "${BINARY}"


### PR DESCRIPTION
In this PR:

- Closes #199. Applies the #196 fix to the remaining 7 actions so consumers SHA-pinning these actions actually pin the binary too, rather than relying on the mutable `dev` release asset.
- Factors the source-hash / cache / setup-go / `go build` steps into a new local composite action `build-go-binary` and migrates all 8 actions onto it (including `backport`, whose inline copy goes away).
- Removes the now-unused `binary_release_tag` input from all 7 actions and the leftover doc example in `migrate-open-prs/README.md`. Composite actions silently ignore unknown inputs, so existing consumers still passing it won't break.

Note to reviewers:

- Review with "hide whitespace changes" enabled