### PR TITLE
backport: default committer identity for the local cherry-pick

### DIFF
--- a/backport/backport_test.go
+++ b/backport/backport_test.go
@@ -234,7 +234,7 @@ func TestBackport(t *testing.T) {
 			"git fetch origin release-12.0.0:refs/remotes/origin/release-12.0.0",
 			"git fetch --shallow-since=1577923200",
 			"git checkout -b backport-100-to-release-12.0.0 origin/release-12.0.0",
-			"git cherry-pick -x asdf1234",
+			"git -c user.name=grafanabot -c user.email=bot@grafana.com cherry-pick -x asdf1234",
 			"git rev-parse origin/release-12.0.0",
 			"git diff --no-renames --name-status -z fdsa4321 HEAD",
 			"git log -1 --format=%B HEAD",
@@ -251,7 +251,7 @@ func TestBackport(t *testing.T) {
 	t.Run("Backport comments", func(t *testing.T) {
 		// Simulate an error being returned from the 'git cherry-pick command'
 		runner := newErrorRunner(map[string]error{
-			"git cherry-pick -x asdf1234": errors.New("The process '/usr/bin/git' failed with exit code 1"),
+			"git -c user.name=grafanabot -c user.email=bot@grafana.com cherry-pick -x asdf1234": errors.New("The process '/usr/bin/git' failed with exit code 1"),
 		})
 
 		var comment *github.IssueComment

--- a/backport/cherrypick.go
+++ b/backport/cherrypick.go
@@ -47,7 +47,16 @@ func CreateCherryPickBranch(ctx context.Context, runner CommandRunner, branch st
 		return fmt.Errorf("error creating branch: %w", err)
 	}
 
-	_, err := runner.Run(ctx, "git", "cherry-pick", "-x", opts.SourceSHA)
+	// `git cherry-pick` refuses to create the local commit without a committer identity, so
+	// pass one inline via `-c`. The local commit's committer is overwritten by GitHub's
+	// web-flow key when the commit is published via createCommitOnBranch, so the value is
+	// purely a placeholder — but it must be non-empty. Using `-c` keeps `.git/config`
+	// untouched. The identity matches the one set by pkg/toolkit/toolkit.go.
+	_, err := runner.Run(ctx, "git",
+		"-c", "user.name=grafanabot",
+		"-c", "user.email=bot@grafana.com",
+		"cherry-pick", "-x", opts.SourceSHA,
+	)
 	if err != nil {
 		if err := ResolveBettererConflict(ctx, runner); err == nil {
 			return nil

--- a/backport/cherrypick_test.go
+++ b/backport/cherrypick_test.go
@@ -32,7 +32,7 @@ func TestCreateCherryPickBranch(t *testing.T) {
 				},
 			}
 			runner = newErrorRunner(map[string]error{
-				"git cherry-pick -x asdf1234":               errors.New("cherry-pick error"),
+				"git -c user.name=grafanabot -c user.email=bot@grafana.com cherry-pick -x asdf1234":               errors.New("cherry-pick error"),
 				"git diff -s --exit-code .betterer.results": errors.New("command returned 1"),
 			})
 		)
@@ -42,7 +42,7 @@ func TestCreateCherryPickBranch(t *testing.T) {
 			"git fetch origin release-1.0.0:refs/remotes/origin/release-1.0.0",
 			"git fetch --shallow-since=1577923200",
 			"git checkout -b example origin/release-1.0.0",
-			"git cherry-pick -x asdf1234",
+			"git -c user.name=grafanabot -c user.email=bot@grafana.com cherry-pick -x asdf1234",
 			"git diff -s --exit-code .betterer.results",
 			"yarn run betterer",
 			"git add .betterer.results",
@@ -74,7 +74,7 @@ func TestCreateCherryPickBranch(t *testing.T) {
 				},
 			}
 			runner = newErrorRunner(map[string]error{
-				"git cherry-pick -x asdf1234": errors.New("cherry-pick error"),
+				"git -c user.name=grafanabot -c user.email=bot@grafana.com cherry-pick -x asdf1234": errors.New("cherry-pick error"),
 			})
 		)
 
@@ -83,7 +83,7 @@ func TestCreateCherryPickBranch(t *testing.T) {
 			"git fetch origin release-1.0.0:refs/remotes/origin/release-1.0.0",
 			"git fetch --shallow-since=1577923200",
 			"git checkout -b example origin/release-1.0.0",
-			"git cherry-pick -x asdf1234",
+			"git -c user.name=grafanabot -c user.email=bot@grafana.com cherry-pick -x asdf1234",
 			"git diff -s --exit-code .betterer.results",
 			"git cherry-pick --abort",
 		}


### PR DESCRIPTION
## What

Pass an inline committer to the local `git cherry-pick` in the backport action via:

```go
runner.Run(ctx, "git",
    "-c", "user.name=grafanabot",
    "-c", "user.email=bot@grafana.com",
    "cherry-pick", "-x", opts.SourceSHA,
)
```

## Why

`git cherry-pick` refuses to create the local commit without a committer identity. The action currently delegates that to consumers — there's no documentation requirement, no enforcement, and the failure mode is a generic git error that doesn't make the cause obvious:

```
error cherry-picking: error running git cherry-pick: ... exit status 128
stderr: Committer identity unknown
*** Please tell me who you are.
```

We just hit this when adopting the action in `grafana/mimir`: https://github.com/grafana/mimir/pull/15472#issuecomment-4563020122. Every future consumer is one omitted `git config user.email …` step away from the same error.

The identity is purely a placeholder — once the local commit is published via `createCommitOnBranch`, GitHub's web-flow key overwrites the committer to `GitHub <noreply@github.com>` (signs the commit with Verified). The value only needs to be non-empty so `git cherry-pick` doesn't bail.

## Why these specific name/email

Matches what `pkg/toolkit/toolkit.go:163-168` already sets elsewhere in this repo (`grafanabot` / `bot@grafana.com`). One identity convention, repo-wide.

## Why `-c` instead of `git config --local …`

`-c` scopes the override to the single `cherry-pick` invocation, leaving the consumer's `.git/config` untouched. No side effects on subsequent git operations in the same workflow.

## Tests

Updated the three fixtures in `backport/backport_test.go` and `backport/cherrypick_test.go` that asserted the exact cherry-pick command string. `go test ./backport/ ./pkg/ghgql/ -count=1` passes.