### PR TITLE
Add mimir-maintainers as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @grafana/grafana-backend-services-squad
+* @grafana/grafana-backend-services-squad @grafana/mimir-maintainers


### PR DESCRIPTION
Add `@grafana/mimir-maintainers` as additional CODEOWNERS, alongside the existing `@grafana/grafana-backend-services-squad`.