### PR TITLE
backport: exit non-zero when any backport target fails

### DIFF
--- a/backport/main.go
+++ b/backport/main.go
@@ -87,11 +87,14 @@ func main() {
 		panic(err)
 	}
 
+	failed := false
 	for _, target := range targets {
 		log := log.With("target", target)
 		mergeBase, err := MergeBase(ctx, client.Repositories, prInfo.RepoOwner, prInfo.RepoName, target.Name, prInfo.Pr.GetBase().GetRef())
 		if err != nil {
 			log.Error("error finding merge-base", "error", err)
+			failed = true
+			continue
 		}
 
 		opts := BackportOpts{
@@ -113,9 +116,14 @@ func main() {
 		prOut, err := Backport(ctx, log, client.PullRequests, client.Issues, client.Issues, client.Git, gqlClient, commandRunner, opts)
 		if err != nil {
 			log.Error("backport failed", "error", err)
+			failed = true
 			continue
 		}
 
 		log.Info("backport successful", "url", prOut.GetURL())
+	}
+
+	if failed {
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Summary

The for-loop over backport targets in `backport/main.go` logged errors and continued without recording them, so the binary always exited 0 — even when every cherry-pick failed. The GitHub Actions job then reported success and the only signal of failure was the bot-posted PR comment, which is easy to miss.

This PR:

- Tracks whether any target failed and `os.Exit(1)` at the end of `main` so the workflow fails loudly.
- Treats a `MergeBase` lookup error as a failure too. Previously it was logged but the loop continued with a zero-value `mergeBase`, which makes `CreateCherryPickBranch` issue `git fetch --shallow-since=0` (the Unix epoch) and hides the real problem.

## Context

Spotted while debugging a backport failure in grafana/mimir: the cherry-pick failed and the bot posted a "failed to backport" comment, but the workflow run was green — see https://github.com/grafana/mimir/actions/runs/26571193611/job/78278472711.

## Test plan

- [ ] Trigger a backport that's expected to succeed and confirm the workflow is green.
- [ ] Trigger a backport with a guaranteed cherry-pick conflict and confirm the workflow turns red (bot still posts the existing failure comment).