### PR TITLE
bump Go to 1.26.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.26.3"
           cache: true
       - run: "go run ci/main.go --do-test --do-build --do-upload"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,6 +11,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.26.3"
           cache: true
       - run: "go run ci/main.go --do-test --do-build"

--- a/Dockerfile.dagger
+++ b/Dockerfile.dagger
@@ -1,3 +1,3 @@
 # This file is used to keep the Docker images used in the CI pipeline by Dagger
 # up-to-update:
-FROM golang:1.21.6
+FROM golang:1.26@sha256:2d6c80227255c3112a4d08e67ba98e58efd3846daf15d9d7d4c389565d881b1a

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/grafana/grafana-github-actions-go
 
-go 1.21
-
-toolchain go1.21.5
+go 1.26
 
 require (
 	dagger.io/dagger v0.9.7


### PR DESCRIPTION
This PR keeps Go up to date, which also makes sure we are using maintained libraries.