### PR TITLE
fix(zizmor): grant id-token:write and pin reusable workflow to SHA

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -12,12 +12,14 @@ jobs:
     permissions:
       actions: read
       contents: read
+      # required by the reusable workflow's nested jobs (job-workflow-ref, grafana-bench)
+      id-token: write
       # required to comment on pull requests with the results of the check
       pull-requests: write
       # required to upload the results to GitHub's code scanning service
       security-events: write
 
-    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@main  # zizmor: ignore[unpinned-uses]
+    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@24a81c0925981b54312bcfc5d670d85fb96d994c # main
     with:
       fail-severity: high
       min-severity: high


### PR DESCRIPTION
## Summary

The `zizmor.yml` workflow currently fails to start with:

> The nested job 'job-workflow-ref' is requesting 'id-token: write', but is only allowed 'id-token: none'.
> The nested job 'grafana-bench' is requesting 'id-token: write', but is only allowed 'id-token: none'.

The reusable `grafana/shared-workflows/.github/workflows/reusable-zizmor.yml` has two nested jobs that need `id-token: write` (one to read the `job_workflow_ref` claim, one for Vault auth in `grafana-bench`). A called workflow can't request more permissions than the caller grants, so the caller has to permit it too.

- Add `id-token: write` to the caller's permissions block.
- Pin the reusable workflow to commit `24a81c0` (current `main` HEAD) instead of `@main`, and drop the `zizmor: ignore[unpinned-uses]` suppression that's no longer needed.

## Test plan

- [ ] Workflow validates and runs on this PR (the original error happens at workflow-parse time, so PR CI itself is the test).
- [ ] Zizmor job completes successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)