### PR TITLE
fix(backport): configure git HTTP credentials for git fetch operations

### DIFF
--- a/backport/action.yml
+++ b/backport/action.yml
@@ -65,6 +65,11 @@ runs:
 
     - shell: bash
       env:
+        TOKEN: ${{ inputs.token }}
+      run: git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
+
+    - shell: bash
+      env:
         GITHUB_TOKEN: ${{ inputs.token }}
         DIR: ${{ inputs.path }}
         PR_LABEL: ${{ inputs.pr_label }}
@@ -76,3 +81,9 @@ runs:
         set -euo pipefail
         cd "${DIR}"
         "${BINARY}"
+
+    - if: always()
+      shell: bash
+      env:
+        TOKEN: ${{ inputs.token }}
+      run: git config --global --unset-all url."https://x-access-token:${TOKEN}@github.com/".insteadOf || true


### PR DESCRIPTION
## Problem

The `backport` action accepts a `token:` input documented as "GitHub token with access to all necessary repositories", implying the action handles authentication internally. However, `cherrypick.go` calls `git fetch origin <sha>` and `git fetch origin <branch>` over HTTPS, but the token was only set as `GITHUB_TOKEN` for Go API calls — never configured for git HTTP auth.

Callers using `persist-credentials: false` on their checkout step (recommended security practice) hit:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

Discovered when another repo was migrated to this action.

## Fix

Add a credential-setup step before the binary-execution step and a credential-teardown step after it (with `if: always()`), using the `url.insteadOf` pattern established in Grafana CI (e.g. `update_vendored_mimir_cron.yml`):

```yaml
- shell: bash
  env:
    TOKEN: ${{ inputs.token }}
  run: git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
```

The rewrite targets `https://github.com/` (no org-specific path) so it covers any repo the action may need to fetch from.

The teardown step runs with `if: always()` to clean up the global git config even if the binary step fails.