### PR TITLE
fix(backport): embed token in origin remote URL for git fetch auth

### DIFF
--- a/backport/action.yml
+++ b/backport/action.yml
@@ -65,6 +65,11 @@ runs:
 
     - shell: bash
       env:
+        TOKEN: ${{ inputs.token }}
+      run: git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
+
+    - shell: bash
+      env:
         GITHUB_TOKEN: ${{ inputs.token }}
         DIR: ${{ inputs.path }}
         PR_LABEL: ${{ inputs.pr_label }}
@@ -76,3 +81,9 @@ runs:
         set -euo pipefail
         cd "${DIR}"
         "${BINARY}"
+
+    - if: always()
+      shell: bash
+      env:
+        TOKEN: ${{ inputs.token }}
+      run: git config --global --unset-all url."https://x-access-token:${TOKEN}@github.com/".insteadOf || true

--- a/backport/action.yml
+++ b/backport/action.yml
@@ -65,11 +65,6 @@ runs:
 
     - shell: bash
       env:
-        TOKEN: ${{ inputs.token }}
-      run: git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
-
-    - shell: bash
-      env:
         GITHUB_TOKEN: ${{ inputs.token }}
         DIR: ${{ inputs.path }}
         PR_LABEL: ${{ inputs.pr_label }}
@@ -81,9 +76,3 @@ runs:
         set -euo pipefail
         cd "${DIR}"
         "${BINARY}"
-
-    - if: always()
-      shell: bash
-      env:
-        TOKEN: ${{ inputs.token }}
-      run: git config --global --unset-all url."https://x-access-token:${TOKEN}@github.com/".insteadOf || true

--- a/backport/backport.go
+++ b/backport/backport.go
@@ -44,6 +44,11 @@ type BackportOpts struct {
 
 	// RunID is the ID of the run of the GitHub action that is running this.
 	RunID string
+
+	// GitToken is used to authenticate git fetch operations over HTTPS.
+	// When set, CreateCherryPickBranch temporarily rewrites the origin remote
+	// URL to embed the token, then restores it afterwards.
+	GitToken string
 }
 
 type BackportClient interface {

--- a/backport/cherrypick.go
+++ b/backport/cherrypick.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 )
 
 func ResolveBettererConflict(ctx context.Context, runner CommandRunner) error {
@@ -28,6 +29,18 @@ func ResolveBettererConflict(ctx context.Context, runner CommandRunner) error {
 }
 
 func CreateCherryPickBranch(ctx context.Context, runner CommandRunner, branch string, opts BackportOpts) error {
+	if opts.GitToken != "" {
+		origURL, err := runner.Run(ctx, "git", "remote", "get-url", "origin")
+		if err != nil {
+			return fmt.Errorf("error getting origin URL: %w", err)
+		}
+		authURL := strings.Replace(origURL, "https://github.com/", "https://x-access-token:"+opts.GitToken+"@github.com/", 1)
+		if _, err := runner.Run(ctx, "git", "remote", "set-url", "origin", authURL); err != nil {
+			return fmt.Errorf("error setting origin URL: %w", err)
+		}
+		defer runner.Run(ctx, "git", "remote", "set-url", "origin", origURL) //nolint:errcheck
+	}
+
 	// 1. Ensure that we have the commit in the local history to cherry-pick
 	if _, err := runner.Run(ctx, "git", "fetch", "origin", opts.SourceSHA); err != nil {
 		return fmt.Errorf("error fetching source commit: %w", err)

--- a/backport/cherrypick_test.go
+++ b/backport/cherrypick_test.go
@@ -84,7 +84,7 @@ func TestCreateCherryPickBranch(t *testing.T) {
 
 		expect := []string{
 			"git remote get-url origin",
-			"git remote set-url origin https://x-access-token:test-token@github.com/test-owner/test-repo.git",
+			"git remote set-url origin https://x-access-token:test-token@github.com/test-owner/test-repo.git", // trufflehog:ignore
 			"git fetch origin asdf1234",
 			"git fetch origin release-1.0.0:refs/remotes/origin/release-1.0.0",
 			"git fetch --shallow-since=1577923200",
@@ -127,7 +127,7 @@ func TestCreateCherryPickBranch(t *testing.T) {
 
 		expect := []string{
 			"git remote get-url origin",
-			"git remote set-url origin https://x-access-token:test-token@github.com/test-owner/test-repo.git",
+			"git remote set-url origin https://x-access-token:test-token@github.com/test-owner/test-repo.git", // trufflehog:ignore
 			"git fetch origin asdf1234",
 			"git fetch origin release-1.0.0:refs/remotes/origin/release-1.0.0",
 			"git fetch --shallow-since=1577923200",

--- a/backport/cherrypick_test.go
+++ b/backport/cherrypick_test.go
@@ -54,6 +54,94 @@ func TestCreateCherryPickBranch(t *testing.T) {
 		require.Equal(t, expect, runner.History.Commands)
 	})
 
+	t.Run("It should configure and restore origin URL when GitToken is set", func(t *testing.T) {
+		var (
+			testCommitDate, _ = time.Parse(time.RFC3339, "2020-01-02T00:00:00Z")
+			branch            = "example"
+			opts              = BackportOpts{
+				GitToken: "test-token",
+				Target: ghutil.Branch{
+					Name: "release-1.0.0",
+					SHA:  "fdsa4321",
+				},
+				SourceSHA:        "asdf1234",
+				SourceCommitDate: testCommitDate,
+				MergeBase: &github.Commit{
+					Committer: &github.CommitAuthor{
+						Date: &github.Timestamp{
+							Time: testCommitDate,
+						},
+					},
+				},
+			}
+			runner = &mockRunner{
+				Commands: []string{},
+				Outputs: map[string]string{
+					"git remote get-url origin": "https://github.com/test-owner/test-repo.git",
+				},
+			}
+		)
+
+		expect := []string{
+			"git remote get-url origin",
+			"git remote set-url origin https://x-access-token:test-token@github.com/test-owner/test-repo.git",
+			"git fetch origin asdf1234",
+			"git fetch origin release-1.0.0:refs/remotes/origin/release-1.0.0",
+			"git fetch --shallow-since=1577923200",
+			"git checkout -b example origin/release-1.0.0",
+			"git -c user.name=grafanabot -c user.email=bot@grafana.com cherry-pick -x asdf1234",
+			"git remote set-url origin https://github.com/test-owner/test-repo.git",
+		}
+
+		require.NoError(t, CreateCherryPickBranch(context.Background(), runner, branch, opts))
+		require.Equal(t, expect, runner.Commands)
+	})
+
+	t.Run("It should restore origin URL even if cherry-pick fails", func(t *testing.T) {
+		var (
+			testCommitDate, _ = time.Parse(time.RFC3339, "2020-01-02T00:00:00Z")
+			branch            = "example"
+			opts              = BackportOpts{
+				GitToken: "test-token",
+				Target: ghutil.Branch{
+					Name: "release-1.0.0",
+					SHA:  "fdsa4321",
+				},
+				SourceSHA:        "asdf1234",
+				SourceCommitDate: testCommitDate,
+				MergeBase: &github.Commit{
+					Committer: &github.CommitAuthor{
+						Date: &github.Timestamp{
+							Time: testCommitDate,
+						},
+					},
+				},
+			}
+			runner = newErrorRunner(map[string]error{
+				"git -c user.name=grafanabot -c user.email=bot@grafana.com cherry-pick -x asdf1234": errors.New("cherry-pick error"),
+			})
+		)
+		runner.History.Outputs = map[string]string{
+			"git remote get-url origin": "https://github.com/test-owner/test-repo.git",
+		}
+
+		expect := []string{
+			"git remote get-url origin",
+			"git remote set-url origin https://x-access-token:test-token@github.com/test-owner/test-repo.git",
+			"git fetch origin asdf1234",
+			"git fetch origin release-1.0.0:refs/remotes/origin/release-1.0.0",
+			"git fetch --shallow-since=1577923200",
+			"git checkout -b example origin/release-1.0.0",
+			"git -c user.name=grafanabot -c user.email=bot@grafana.com cherry-pick -x asdf1234",
+			"git diff -s --exit-code .betterer.results",
+			"git cherry-pick --abort",
+			"git remote set-url origin https://github.com/test-owner/test-repo.git",
+		}
+
+		require.Error(t, CreateCherryPickBranch(context.Background(), runner, branch, opts))
+		require.Equal(t, expect, runner.History.Commands)
+	})
+
 	t.Run("It should return an error if there was a non-betterer conflict", func(t *testing.T) {
 		var (
 			testCommitDate, _ = time.Parse(time.RFC3339, "2020-01-02T00:00:00Z")

--- a/backport/exec_test.go
+++ b/backport/exec_test.go
@@ -42,9 +42,9 @@ func newErrorRunner(errors map[string]error) *errorRunner {
 
 func (r *errorRunner) Run(ctx context.Context, command string, args ...string) (string, error) {
 	cmd := strings.Join(append([]string{command}, args...), " ")
-	_, _ = r.History.Run(ctx, command, args...)
+	out, _ := r.History.Run(ctx, command, args...)
 	if err, ok := r.Errors[cmd]; ok {
 		return "", err
 	}
-	return "", nil
+	return out, nil
 }

--- a/backport/main.go
+++ b/backport/main.go
@@ -109,6 +109,7 @@ func main() {
 			Repository:        prInfo.RepoName,
 			MergeBase:         mergeBase,
 			RunID:             runID,
+			GitToken:          token,
 		}
 
 		commandRunner := NewShellCommandRunner(log)


### PR DESCRIPTION
## Problem

The `backport` action's `token:` input is documented as "GitHub token with access to all necessary repositories", but `cherrypick.go` calls `git fetch origin` over HTTPS without any HTTP credential configuration. Callers using `persist-credentials: false` on their checkout step hit:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

## Alternative to #220

PR #220 fixes this by adding `git config --global url."https://x-access-token:...@github.com/".insteadOf` steps to `action.yml`. That works, but `url.insteadOf` is written to the runner's global git config — it rewrites HTTPS URLs for every repo on the machine for the lifetime of the job.

This PR fixes it in the Go code instead, scoped to the `origin` remote of the checked-out repo:

1. Before the `git fetch` calls, read the current origin URL with `git remote get-url origin` and rewrite it to embed the token.
2. After (via `defer`, so it runs on both success and error), restore the original URL with `git remote set-url origin`.

This matches the pattern already used in `pkg/toolkit/toolkit.go` (`CloneRepository` embeds the token directly in the clone URL), and the mutation is limited to the single remote in the current repo rather than the runner's global git config.

## Changes

- `backport/backport.go`: add `GitToken string` to `BackportOpts`
- `backport/cherrypick.go`: get-url / set-url / defer-restore around the fetch calls when `GitToken` is set
- `backport/main.go`: pass `token` as `GitToken` in `BackportOpts`
- `backport/exec_test.go`: make `errorRunner` return outputs from its inner mock (backward-compatible)
- `backport/cherrypick_test.go`: two new cases — credentials configured on success, credentials restored on cherry-pick failure

## Follow-up

Once merged: update the pinned SHA in `backport.yml`.