### PR TITLE
Backport: Do not panic on PR without labels

### DIFF
--- a/backport/main.go
+++ b/backport/main.go
@@ -75,13 +75,13 @@ func main() {
 		panic("PR hasn't been merged yet")
 	}
 
-	if len(prInfo.Labels) == 0 {
-		panic("PR has no labels")
-	}
-
 	log = log.With("repo", fmt.Sprintf("%s/%s", prInfo.RepoOwner, prInfo.RepoName), "pull_request", prInfo.Pr.GetNumber())
 
 	targetNames := BackportTargetsFromLabels(prInfo.Labels, "backport ")
+	if len(targetNames) == 0 {
+		log.Info("no backport labels found, nothing to do")
+		return
+	}
 	targets, err := BackportTargets(ctx, log, client.Repositories, prInfo.RepoOwner, prInfo.RepoName, targetNames)
 	if err != nil {
 		panic(err)

--- a/backport/release_branches_test.go
+++ b/backport/release_branches_test.go
@@ -42,6 +42,18 @@ func TestBackportTargetsFromLabels(t *testing.T) {
 			"v11.0.x",
 		}, targets)
 	})
+
+	t.Run("with no labels", func(t *testing.T) {
+		targets := BackportTargetsFromLabels(nil, "backport ")
+		require.Empty(t, targets)
+	})
+
+	t.Run("with only non-backport labels", func(t *testing.T) {
+		labels := []string{"type/bug", "release/latest", "add-to-changelog"}
+
+		targets := BackportTargetsFromLabels(labels, "backport ")
+		require.Empty(t, targets)
+	})
 }
 
 func TestBackportTarget(t *testing.T) {


### PR DESCRIPTION
Since we removed the requirement for marking PRs with `no-backport` label, the action has been panicking unnecessarily and making the CI checks "red" ❌ 

