### PR TITLE
Backport: Filter protected branches in-code for faster listing

### DIFF
--- a/pkg/ghutil/release_branches.go
+++ b/pkg/ghutil/release_branches.go
@@ -97,14 +97,13 @@ func MajorMinorPatch(v string) (string, string, string) {
 func GetReleaseBranches(ctx context.Context, log *slog.Logger, client BranchClient, owner, repo string) ([]*github.Branch, error) {
 	var (
 		page     int
-		count    = 50
+		count    = 100
 		branches = []*github.Branch{}
 	)
 
 	for {
 		log.Debug("listing branches", "page", page, "count", count)
 		b, r, err := client.ListBranches(ctx, owner, repo, &github.BranchListOptions{
-			Protected: github.Bool(true),
 			ListOptions: github.ListOptions{
 				Page:    page,
 				PerPage: count,
@@ -114,7 +113,13 @@ func GetReleaseBranches(ctx context.Context, log *slog.Logger, client BranchClie
 			return nil, err
 		}
 
-		branches = append(branches, b...)
+		for _, branch := range b {
+			// Filter here rather than sending the filtered request to the API,
+			// as it is slower and it times out with 504 on repos with thousands of branches.
+			if branch.Protected != nil && *branch.Protected {
+				branches = append(branches, branch)
+			}
+		}
 
 		if r.NextPage == 0 {
 			break

--- a/pkg/ghutil/release_branches_test.go
+++ b/pkg/ghutil/release_branches_test.go
@@ -1,0 +1,54 @@
+package ghutil
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/google/go-github/v50/github"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetReleaseBranches(t *testing.T) {
+	branch := func(name string, protected bool) *github.Branch {
+		return &github.Branch{Name: github.String(name), Protected: github.Bool(protected)}
+	}
+
+	client := &fakeBranchClient{
+		pages: [][]*github.Branch{
+			{branch("release-12.1.4", true), branch("some-feature", false)},
+			{branch("release-12.2.0", true), branch("release-12.1.5", false)},
+		},
+	}
+
+	branches, err := GetReleaseBranches(t.Context(), slog.New(slog.NewTextHandler(io.Discard, nil)), client, "grafana", "grafana")
+	require.NoError(t, err)
+
+	// Only keep protected branches
+	names := make([]string, len(branches))
+	for i, b := range branches {
+		names[i] = b.GetName()
+	}
+	require.Equal(t, []string{"release-12.1.4", "release-12.2.0"}, names)
+}
+
+type fakeBranchClient struct{ pages [][]*github.Branch }
+
+func (f *fakeBranchClient) ListBranches(_ context.Context, _, _ string, opts *github.BranchListOptions) ([]*github.Branch, *github.Response, error) {
+	page := opts.Page
+	if page == 0 {
+		page = 1
+	}
+
+	resp := &github.Response{}
+	if page < len(f.pages) {
+		resp.NextPage = page + 1
+	}
+
+	return f.pages[page-1], resp, nil
+}
+
+func (f *fakeBranchClient) GetBranch(_ context.Context, _, _, _ string, _ bool) (*github.Branch, *github.Response, error) {
+	return nil, nil, nil
+}


### PR DESCRIPTION
When listing the branches, we initially send a query with a filter `protected=true`, which makes the API response ~5x slower, and I believe that is causing some 504 responses.

Locally:
```
~ time gh api '/repos/grafana/grafana-enterprise/branches?per_page=100&page=2'          
0.04s user 0.04s system 3% cpu 2.323 total

~ time gh api '/repos/grafana/grafana-enterprise/branches?protected=true&per_page=100&page=2'
0.04s user 0.03s system 0% cpu 9.872 total
```

Whereas the unfiltered request takes ~2s.

On a repo with 2000 branches, we need to issue 20 requests, each taking ~2s which is equivalent to 40s. With the previous approach, that would take 200s, but most likely would time out.

So instead, we filter for protected branches in the code after the API response.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Same intended output (protected branches only); risk is mainly if unfiltered list responses omit or mis-set the Protected flag, which would change which branches are kept.
> 
> **Overview**
> **`GetReleaseBranches`** no longer passes `protected=true` to GitHub’s list-branches API. It paginates unfiltered branch lists ( **`per_page` raised from 50 to 100** ) and keeps only branches where **`Protected` is true** in application code, avoiding slow API-side filtering that was causing **504 timeouts** on repos with thousands of branches.
> 
> Adds **`TestGetReleaseBranches`** with a fake **`BranchClient`** to assert only protected release branches are returned across paginated responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4a39f2b4e0ea6d4d976eb5e868302b2987b0b8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->