### PR TITLE
feat: Add title template for backports

### DIFF
--- a/backport/action.yml
+++ b/backport/action.yml
@@ -19,6 +19,10 @@ inputs:
   repo_name:
     description: The name of the repository the PR is in
     required: false
+  pr_title_template:
+    description: Template for backport PR titles. Use {{branch}} and {{title}} placeholders.
+    required: false
+    default: "[{{branch}}] {{title}}"
 
 runs:
   using: composite
@@ -71,6 +75,7 @@ runs:
         PR_NUMBER: ${{ inputs.pr_number }}
         REPO_OWNER: ${{ inputs.repo_owner }}
         REPO_NAME: ${{ inputs.repo_name }}
+        PR_TITLE_TEMPLATE: ${{ inputs.pr_title_template }}
         BINARY: /tmp/backport
       run: |
         set -euo pipefail

--- a/backport/backport.go
+++ b/backport/backport.go
@@ -21,6 +21,9 @@ type BackportOpts struct {
 	// SourceTitle is the title of the source PR which will be reused in the backport PRs
 	SourceTitle string
 
+	// TitleTemplate controls backport PR title formatting via {{branch}} and {{title}} placeholders.
+	TitleTemplate string
+
 	// SourceBody is the body of the source PR which will be reused in the backport PRs
 	SourceBody string
 
@@ -64,7 +67,7 @@ type CommentClient interface {
 }
 
 func CreatePullRequest(ctx context.Context, client BackportClient, issueClient IssueClient, branch string, opts BackportOpts) (*github.PullRequest, error) {
-	title := fmt.Sprintf("[%s] %s", opts.Target.Name, opts.SourceTitle)
+	title := FormatBackportTitle(opts.TitleTemplate, opts.Target.Name, opts.SourceTitle)
 
 	body := fmt.Sprintf("Backport %s from #%d <sup>[job run](https://github.com/%s/%s/actions/runs/%s)</sup>\n\n---\n\n%s", opts.SourceSHA, opts.PullRequestNumber, opts.Owner, opts.Repository, opts.RunID, opts.SourceBody)
 

--- a/backport/backport_test.go
+++ b/backport/backport_test.go
@@ -248,6 +248,76 @@ func TestBackport(t *testing.T) {
 		require.Equal(t, []string{"Example Bug Fix"}, gqlClient.headlines)
 	})
 
+	t.Run("Successful backport with suffix title template", func(t *testing.T) {
+		createFn := func(ctx context.Context, owner string, repo string, pull *github.NewPullRequest) (*github.PullRequest, *github.Response, error) {
+			return &github.PullRequest{
+				Number: github.Int(101),
+				Body:   pull.Body,
+				Title:  pull.Title,
+			}, nil, nil
+		}
+		editFn := func(ctx context.Context, owner string, repo string, number int, issue *github.IssueRequest) (*github.Issue, *github.Response, error) {
+			labels := make([]*github.Label, len(issue.GetLabels()))
+			for i, v := range issue.GetLabels() {
+				labels[i] = &github.Label{
+					Name: github.String(v),
+				}
+			}
+			return &github.Issue{
+				Labels: labels,
+			}, nil, nil
+		}
+
+		tmpDir := t.TempDir()
+		oldwd, _ := os.Getwd()
+		require.NoError(t, os.Chdir(tmpDir))
+		t.Cleanup(func() { _ = os.Chdir(oldwd) })
+		require.NoError(t, os.WriteFile("backported-file.txt", []byte("hello\n"), 0o644))
+
+		runner := newMockRunner()
+		runner.Outputs = map[string]string{
+			"git rev-parse origin/release-12.0.0":                  "fdsa4321",
+			"git diff --no-renames --name-status -z fdsa4321 HEAD": "A\x00backported-file.txt\x00",
+			"git log -1 --format=%B HEAD":                          "Example Bug Fix\n\nBody paragraph",
+			"git log -1 --format=%an asdf1234":                     "Original Author",
+			"git log -1 --format=%ae asdf1234":                     "orig@example.com",
+		}
+
+		client := &TestBackportClient{
+			CreateFunc: createFn,
+			EditFunc:   editFn,
+		}
+
+		commitDate, _ := time.Parse(time.RFC3339, "2020-01-02T00:00:00Z")
+		pr, err := Backport(context.Background(), slog.Default(), client, client, client, &noopRefClient{}, &noopSignedCommitClient{}, runner, BackportOpts{
+			PullRequestNumber: 100,
+			SourceSHA:         "asdf1234",
+			SourceTitle:       "Example Bug Fix",
+			TitleTemplate:     "{{title}} [{{branch}}]",
+			SourceBody:        "Example bug fix body",
+			SourceCommitDate:  commitDate,
+			MergeBase: &github.Commit{
+				Committer: &github.CommitAuthor{
+					Date: &github.Timestamp{
+						Time: commitDate,
+					},
+				},
+			},
+			Target: ghutil.Branch{
+				Name: "release-12.0.0",
+				SHA:  "fdsa4321",
+			},
+			Labels: []*github.Label{
+				{Name: github.String("type/bug")},
+			},
+			Owner:      "grafana",
+			Repository: "grafana",
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, *pr.Title, "Example Bug Fix [release-12.0.0]")
+	})
+
 	t.Run("Backport comments", func(t *testing.T) {
 		// Simulate an error being returned from the 'git cherry-pick command'
 		runner := newErrorRunner(map[string]error{

--- a/backport/comment.go
+++ b/backport/comment.go
@@ -41,7 +41,7 @@ func CommentFailure(ctx context.Context, client CommentClient, opts FailureOpts)
 	}
 
 	data := CommentData{
-		BackportTitle:           fmt.Sprintf("[%s] %s", opts.Target.Name, opts.SourceTitle),
+		BackportTitle:           FormatBackportTitle(opts.TitleTemplate, opts.Target.Name, opts.SourceTitle),
 		Target:                  opts.Target.Name,
 		Error:                   opts.Error.Error(),
 		BackportBranch:          branch,

--- a/backport/main.go
+++ b/backport/main.go
@@ -14,14 +14,19 @@ import (
 )
 
 type Inputs struct {
-	Title  string
-	Labels []*github.Label
+	TitleTemplate string
+	Labels        []*github.Label
 }
 
 func GetInputs() Inputs {
 	var (
-		labelsStr = githubactions.GetInput("labels_to_add")
+		labelsStr     = githubactions.GetInput("labels_to_add")
+		titleTemplate = os.Getenv("PR_TITLE_TEMPLATE")
 	)
+
+	if titleTemplate == "" {
+		titleTemplate = githubactions.GetInput("pr_title_template")
+	}
 
 	labelStrings := strings.Split(labelsStr, ",")
 	labels := make([]*github.Label, len(labelStrings))
@@ -32,7 +37,8 @@ func GetInputs() Inputs {
 	}
 
 	return Inputs{
-		Labels: labels,
+		TitleTemplate: titleTemplate,
+		Labels:        labels,
 	}
 }
 
@@ -102,6 +108,7 @@ func main() {
 			SourceSHA:         prInfo.Pr.GetMergeCommitSHA(),
 			SourceCommitDate:  prInfo.Pr.GetMergedAt().Time,
 			SourceTitle:       prInfo.Pr.GetTitle(),
+			TitleTemplate:     inputs.TitleTemplate,
 			SourceBody:        prInfo.Pr.GetBody(),
 			Target:            target,
 			Labels:            append(inputs.Labels, prInfo.Pr.Labels...),

--- a/backport/title.go
+++ b/backport/title.go
@@ -1,0 +1,15 @@
+package main
+
+import "strings"
+
+const defaultTitleTemplate = "[{{branch}}] {{title}}"
+
+func FormatBackportTitle(template, branch, title string) string {
+	if template == "" {
+		template = defaultTitleTemplate
+	}
+	return strings.NewReplacer(
+		"{{branch}}", branch,
+		"{{title}}", title,
+	).Replace(template)
+}

--- a/backport/title_test.go
+++ b/backport/title_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatBackportTitle(t *testing.T) {
+	t.Run("default template when empty", func(t *testing.T) {
+		assert.Equal(t, "[release-12.0.0] Example Bug Fix", FormatBackportTitle("", "release-12.0.0", "Example Bug Fix"))
+	})
+
+	t.Run("explicit default template", func(t *testing.T) {
+		assert.Equal(t, "[gel-release-3.6] fix: something", FormatBackportTitle("[{{branch}}] {{title}}", "gel-release-3.6", "fix: something"))
+	})
+
+	t.Run("suffix template", func(t *testing.T) {
+		assert.Equal(t, "fix: something [gel-release-3.6]", FormatBackportTitle("{{title}} [{{branch}}]", "gel-release-3.6", "fix: something"))
+	})
+}


### PR DESCRIPTION
Loki utilizes conventional commits, and the current backport action prepends the branch name to the PR in a backport, in a format like `[branch] pr title`.  This breaks the conventional commit standard.

This PR adds support for a template, so that the backport PR titles can be customized slightly - notably, to move the branch name, should it be desired.  The default formatting should remain as is, but this should surface an option to configure this.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change to PR titles and failure-comment text; cherry-pick and publish behavior are unchanged, with tests covering default and custom templates.
> 
> **Overview**
> Adds an optional **`pr_title_template`** input to the backport action (default **`[{{branch}}] {{title}}`**) so consumers can control how backport PR titles are built instead of a fixed branch prefix.
> 
> Backport PR creation and **failure comments** now share **`FormatBackportTitle`**, which substitutes **`{{branch}}`** and **`{{title}}`**. The template is passed via **`PR_TITLE_TEMPLATE`** / action input into **`BackportOpts`**, enabling formats like **`{{title}} [{{branch}}]`** for conventional-commit-friendly titles while keeping the previous default when unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6bbcffe1e570ac34c0b1dd3b6db33836db20e5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->