### PR TITLE
backport: auto-resolve betterer and go.sum conflicts

### DIFF
--- a/backport/cherrypick.go
+++ b/backport/cherrypick.go
@@ -8,6 +8,11 @@ import (
 )
 
 func ResolveBettererConflict(ctx context.Context, runner CommandRunner) error {
+	// If .betterer.results isn't tracked, there's no betterer conflict to resolve.
+	if _, err := runner.Run(ctx, "git", "ls-files", "--error-unmatch", ".betterer.results"); err != nil {
+		return errors.New(".betterer.results does not exist")
+	}
+
 	// git diff -s --exit-code returns 1 if the file has changed
 	if _, err := runner.Run(ctx, "git", "diff", "-s", "--exit-code", ".betterer.results"); err == nil {
 		return errors.New(".better.results has not changed")

--- a/backport/cherrypick.go
+++ b/backport/cherrypick.go
@@ -33,6 +33,34 @@ func ResolveBettererConflict(ctx context.Context, runner CommandRunner) error {
 	return nil
 }
 
+func ResolveGoSumConflict(ctx context.Context, runner CommandRunner) error {
+	// Only attempt to fix the conflict automatically when go.sum is the single
+	// conflicting file. --diff-filter=U lists the paths still unmerged.
+	out, err := runner.Run(ctx, "git", "diff", "--name-only", "--diff-filter=U")
+	if err != nil {
+		return err
+	}
+
+	conflicts := strings.Fields(out)
+	if len(conflicts) != 1 || conflicts[0] != "go.sum" {
+		return errors.New("go.sum is not the only conflicting file")
+	}
+
+	if _, err := runner.Run(ctx, "go", "mod", "tidy"); err != nil {
+		return err
+	}
+
+	if _, err := runner.Run(ctx, "git", "add", "go.mod", "go.sum"); err != nil {
+		return err
+	}
+
+	if _, err := runner.Run(ctx, "git", "-c", "core.editor=true", "cherry-pick", "--continue"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func CreateCherryPickBranch(ctx context.Context, runner CommandRunner, branch string, opts BackportOpts) error {
 	if opts.GitToken != "" {
 		origURL, err := runner.Run(ctx, "git", "remote", "get-url", "origin")
@@ -77,6 +105,10 @@ func CreateCherryPickBranch(ctx context.Context, runner CommandRunner, branch st
 	)
 	if err != nil {
 		if err := ResolveBettererConflict(ctx, runner); err == nil {
+			return nil
+		}
+
+		if err := ResolveGoSumConflict(ctx, runner); err == nil {
 			return nil
 		}
 

--- a/backport/cherrypick_test.go
+++ b/backport/cherrypick_test.go
@@ -43,6 +43,7 @@ func TestCreateCherryPickBranch(t *testing.T) {
 			"git fetch --shallow-since=1577923200",
 			"git checkout -b example origin/release-1.0.0",
 			"git -c user.name=grafanabot -c user.email=bot@grafana.com cherry-pick -x asdf1234",
+			"git ls-files --error-unmatch .betterer.results",
 			"git diff -s --exit-code .betterer.results",
 			"yarn run betterer",
 			"git add .betterer.results",
@@ -133,6 +134,7 @@ func TestCreateCherryPickBranch(t *testing.T) {
 			"git fetch --shallow-since=1577923200",
 			"git checkout -b example origin/release-1.0.0",
 			"git -c user.name=grafanabot -c user.email=bot@grafana.com cherry-pick -x asdf1234",
+			"git ls-files --error-unmatch .betterer.results",
 			"git diff -s --exit-code .betterer.results",
 			"git cherry-pick --abort",
 			"git remote set-url origin https://github.com/test-owner/test-repo.git",
@@ -172,7 +174,47 @@ func TestCreateCherryPickBranch(t *testing.T) {
 			"git fetch --shallow-since=1577923200",
 			"git checkout -b example origin/release-1.0.0",
 			"git -c user.name=grafanabot -c user.email=bot@grafana.com cherry-pick -x asdf1234",
+			"git ls-files --error-unmatch .betterer.results",
 			"git diff -s --exit-code .betterer.results",
+			"git cherry-pick --abort",
+		}
+
+		require.Error(t, CreateCherryPickBranch(context.Background(), runner, branch, opts))
+		require.Equal(t, expect, runner.History.Commands)
+	})
+
+	t.Run("It should return an error if .betterer.results does not exist", func(t *testing.T) {
+		var (
+			testCommitDate, _ = time.Parse(time.RFC3339, "2020-01-02T00:00:00Z")
+			branch            = "example"
+			opts              = BackportOpts{
+				Target: ghutil.Branch{
+					Name: "release-1.0.0",
+					SHA:  "fdsa4321",
+				},
+				SourceSHA:        "asdf1234",
+				SourceCommitDate: testCommitDate,
+				MergeBase: &github.Commit{
+					Committer: &github.CommitAuthor{
+						Date: &github.Timestamp{
+							Time: testCommitDate,
+						},
+					},
+				},
+			}
+			runner = newErrorRunner(map[string]error{
+				"git -c user.name=grafanabot -c user.email=bot@grafana.com cherry-pick -x asdf1234": errors.New("cherry-pick error"),
+				"git ls-files --error-unmatch .betterer.results":                                    errors.New("command returned 1"),
+			})
+		)
+
+		expect := []string{
+			"git fetch origin asdf1234",
+			"git fetch origin release-1.0.0:refs/remotes/origin/release-1.0.0",
+			"git fetch --shallow-since=1577923200",
+			"git checkout -b example origin/release-1.0.0",
+			"git -c user.name=grafanabot -c user.email=bot@grafana.com cherry-pick -x asdf1234",
+			"git ls-files --error-unmatch .betterer.results",
 			"git cherry-pick --abort",
 		}
 

--- a/backport/cherrypick_test.go
+++ b/backport/cherrypick_test.go
@@ -32,8 +32,8 @@ func TestCreateCherryPickBranch(t *testing.T) {
 				},
 			}
 			runner = newErrorRunner(map[string]error{
-				"git -c user.name=grafanabot -c user.email=bot@grafana.com cherry-pick -x asdf1234":               errors.New("cherry-pick error"),
-				"git diff -s --exit-code .betterer.results": errors.New("command returned 1"),
+				"git -c user.name=grafanabot -c user.email=bot@grafana.com cherry-pick -x asdf1234": errors.New("cherry-pick error"),
+				"git diff -s --exit-code .betterer.results":                                         errors.New("command returned 1"),
 			})
 		)
 
@@ -136,6 +136,7 @@ func TestCreateCherryPickBranch(t *testing.T) {
 			"git -c user.name=grafanabot -c user.email=bot@grafana.com cherry-pick -x asdf1234",
 			"git ls-files --error-unmatch .betterer.results",
 			"git diff -s --exit-code .betterer.results",
+			"git diff --name-only --diff-filter=U",
 			"git cherry-pick --abort",
 			"git remote set-url origin https://github.com/test-owner/test-repo.git",
 		}
@@ -176,6 +177,7 @@ func TestCreateCherryPickBranch(t *testing.T) {
 			"git -c user.name=grafanabot -c user.email=bot@grafana.com cherry-pick -x asdf1234",
 			"git ls-files --error-unmatch .betterer.results",
 			"git diff -s --exit-code .betterer.results",
+			"git diff --name-only --diff-filter=U",
 			"git cherry-pick --abort",
 		}
 
@@ -215,6 +217,97 @@ func TestCreateCherryPickBranch(t *testing.T) {
 			"git checkout -b example origin/release-1.0.0",
 			"git -c user.name=grafanabot -c user.email=bot@grafana.com cherry-pick -x asdf1234",
 			"git ls-files --error-unmatch .betterer.results",
+			"git diff --name-only --diff-filter=U",
+			"git cherry-pick --abort",
+		}
+
+		require.Error(t, CreateCherryPickBranch(context.Background(), runner, branch, opts))
+		require.Equal(t, expect, runner.History.Commands)
+	})
+
+	t.Run("It should handle go.sum conflicts", func(t *testing.T) {
+		var (
+			testCommitDate, _ = time.Parse(time.RFC3339, "2020-01-02T00:00:00Z")
+			branch            = "example"
+			opts              = BackportOpts{
+				Target: ghutil.Branch{
+					Name: "release-1.0.0",
+					SHA:  "fdsa4321",
+				},
+				SourceSHA:        "asdf1234",
+				SourceCommitDate: testCommitDate,
+				MergeBase: &github.Commit{
+					Committer: &github.CommitAuthor{
+						Date: &github.Timestamp{
+							Time: testCommitDate,
+						},
+					},
+				},
+			}
+			runner = newErrorRunner(map[string]error{
+				"git -c user.name=grafanabot -c user.email=bot@grafana.com cherry-pick -x asdf1234": errors.New("cherry-pick error"),
+				// .betterer.results isn't tracked, so the betterer resolver bails out.
+				"git ls-files --error-unmatch .betterer.results": errors.New("command returned 1"),
+			})
+		)
+		// go.sum is the only conflicting file.
+		runner.History.Outputs = map[string]string{
+			"git diff --name-only --diff-filter=U": "go.sum\n",
+		}
+
+		expect := []string{
+			"git fetch origin asdf1234",
+			"git fetch origin release-1.0.0:refs/remotes/origin/release-1.0.0",
+			"git fetch --shallow-since=1577923200",
+			"git checkout -b example origin/release-1.0.0",
+			"git -c user.name=grafanabot -c user.email=bot@grafana.com cherry-pick -x asdf1234",
+			"git ls-files --error-unmatch .betterer.results",
+			"git diff --name-only --diff-filter=U",
+			"go mod tidy",
+			"git add go.mod go.sum",
+			"git -c core.editor=true cherry-pick --continue",
+		}
+
+		require.NoError(t, CreateCherryPickBranch(context.Background(), runner, branch, opts))
+		require.Equal(t, expect, runner.History.Commands)
+	})
+
+	t.Run("It should not fix go.sum when other files also conflict", func(t *testing.T) {
+		var (
+			testCommitDate, _ = time.Parse(time.RFC3339, "2020-01-02T00:00:00Z")
+			branch            = "example"
+			opts              = BackportOpts{
+				Target: ghutil.Branch{
+					Name: "release-1.0.0",
+					SHA:  "fdsa4321",
+				},
+				SourceSHA:        "asdf1234",
+				SourceCommitDate: testCommitDate,
+				MergeBase: &github.Commit{
+					Committer: &github.CommitAuthor{
+						Date: &github.Timestamp{
+							Time: testCommitDate,
+						},
+					},
+				},
+			}
+			runner = newErrorRunner(map[string]error{
+				"git -c user.name=grafanabot -c user.email=bot@grafana.com cherry-pick -x asdf1234": errors.New("cherry-pick error"),
+				"git ls-files --error-unmatch .betterer.results":                                    errors.New("command returned 1"),
+			})
+		)
+		runner.History.Outputs = map[string]string{
+			"git diff --name-only --diff-filter=U": "go.sum\nmain.go\n",
+		}
+
+		expect := []string{
+			"git fetch origin asdf1234",
+			"git fetch origin release-1.0.0:refs/remotes/origin/release-1.0.0",
+			"git fetch --shallow-since=1577923200",
+			"git checkout -b example origin/release-1.0.0",
+			"git -c user.name=grafanabot -c user.email=bot@grafana.com cherry-pick -x asdf1234",
+			"git ls-files --error-unmatch .betterer.results",
+			"git diff --name-only --diff-filter=U",
 			"git cherry-pick --abort",
 		}
 


### PR DESCRIPTION
## what
two changes to conflict handling in `CreateCherryPickBranch`:

1. `ResolveBettererConflict` now bails out early when `.betterer.results` isn't tracked, instead of treating any cherry-pick conflict as a betterer conflict.
2. new `ResolveGoSumConflict`: when `go.sum` is the *only* conflicting file, run `go mod tidy` to regenerate it and continue the cherry-pick automatically.

## why
the betterer check used `git diff -s --exit-code .betterer.results`, which returns a non-zero exit code both when the file changed *and* when it doesn't exist. so on a repo without `.betterer.results`, every conflict looked like a betterer conflict and we'd run `yarn run betterer` against a missing file. the `git ls-files --error-unmatch` check fixes that.

go.sum conflicts are the other common, mechanically-resolvable case in backports — when it's the only thing in conflict, regenerating it with `go mod tidy` is exactly what a human would do by hand. checking it's the *only* conflict keeps us from masking real code conflicts.

example backport that would've been automated: https://github.com/grafana/mimir/pull/15813

## notes
both resolvers fall through to `git cherry-pick --abort` and surface the original error if they can't help, so behavior for genuine conflicts is unchanged.